### PR TITLE
Nix: Add missing package for mke2fs command

### DIFF
--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -52,6 +52,7 @@
             parted
             fuse2
             bchunk
+            e2fsprogs
             pkg-config
             patchelf
 


### PR DESCRIPTION
Just a quick fix to include a missing package (e2fsprogs) for the nix setup.

I have some other work I wanna do to the nix setup, but I figured it'd be good to get this fix in first.