### PR TITLE
Improve UNC folders handling and add try-catch for Get-Disk failures

### DIFF
--- a/scripts/PSBBN-Launcher-For-Windows.ps1
+++ b/scripts/PSBBN-Launcher-For-Windows.ps1
@@ -282,7 +282,16 @@ function diskPicker {
 
   # list available disks and pick the one to be mounted
   Write-Host "`nList of available disks:"
-  $global:diskList = Get-Disk | Sort -Property Number
+  try {
+    $global:diskList = Get-Disk | Sort -Property Number
+  }
+  catch {
+    Write-Host "
+    ❌ The script failed to list the disks. This is often caused by corruption
+    in the WMI repository. WebSearch '0x80041031,Get-Disk' to find solutions.
+    " -ForegroundColor Red
+    Exit
+  }
   $disksExtras = detectDisksExtras
   $global:diskList | Format-Table -AutoSize -Property `
     Number, `


### PR DESCRIPTION
Improve UNC folders handling according to the finding in [this issue](https://github.com/CosmicScale/PSBBN-Definitive-English-Patch/issues/436#issuecomment-3958205388). Credit to @jrbilodeau for finding the issue and providing tests.

Add try-catch for Get-Disk failures.
In some rare cases described in [this issue](https://github.com/CosmicScale/PSBBN-Definitive-English-Patch/issues/460), the WMI repository can get corrupted and cause Get-Disk to fail.
This PR adds `winmgmt /verifyrepository` to the script, allowing to see the health of the repo, and a try-catch around Get-Disk to fail gracefully.