### PR TITLE
Add optional __boot partition and MWDMA2 kernel patch for IDE→SD adapters

### DIFF
--- a/scripts/Extras.sh
+++ b/scripts/Extras.sh
@@ -589,6 +589,62 @@ cat << "EOF"
 EOF
 }
 
+# Patch vmlinux kernel to use MWDMA2 instead of UDMA4 for DMA
+# Fixes IDE→SD/SATA adapters on SCPH-7000x that fail on UDMA writes
+patch_vmlinux_mwdma2() {
+    local vmlinux="$1"
+    if [ ! -f "$vmlinux" ]; then
+        echo "  [!] vmlinux not found at $vmlinux" | tee -a "${LOG_FILE}"
+        return 1
+    fi
+    echo "  Patching kernel for MWDMA2 (SD card mode)..." | tee -a "${LOG_FILE}"
+    python3 -c "
+import struct, sys, subprocess
+with open('$vmlinux', 'rb+') as f:
+    data = f.read()
+    sym_addr = None
+    # Try nm first, then readelf
+    for cmd in (['nm', '$vmlinux'], ['readelf', '-s', '$vmlinux']):
+        try:
+            out = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode()
+            for line in out.split('\\n'):
+                if 'ide_config_drive_speed' in line:
+                    parts = line.split()
+                    if parts:
+                        try: sym_addr = int(parts[0], 16); break
+                        except: pass
+            if sym_addr: break
+        except: pass
+    if sym_addr:
+        jal = (0x0C << 26) | ((sym_addr >> 2) & 0x3FFFFFF)
+        jal_bytes = struct.pack('<I', jal)
+        old_li = struct.pack('<I', 0x24050044)
+        pattern = jal_bytes + old_li
+        idx = data.find(pattern)
+        if idx >= 0:
+            data = bytearray(data)
+            data[idx + 4] = 0x22
+            f.seek(0); f.write(data); f.truncate()
+            print(f'Patched at file offset 0x{idx+4:x}')
+            sys.exit(0)
+    # Fallback: find JAL + li a1,0x44
+    old_li = struct.pack('<I', 0x24050044)
+    idx = data.find(old_li)
+    while idx >= 0:
+        if idx >= 4:
+            prev = struct.unpack_from('<I', data, idx - 4)[0]
+            if (prev >> 26) == 0x03:
+                data = bytearray(data)
+                data[idx] = 0x22
+                f.seek(0); f.write(data); f.truncate()
+                print(f'Patched at file offset 0x{idx:x}')
+                sys.exit(0)
+        idx = data.find(old_li, idx + 1)
+    print('Pattern not found')
+    sys.exit(1)
+" 2>> "${LOG_FILE}" && echo "  [OK] Kernel patched for MWDMA2" | tee -a "${LOG_FILE}" || echo "  [!] Kernel patch failed - may already be patched" | tee -a "${LOG_FILE}"
+}
+
 # Function for Option 1 - Install PS2 Linux
 option_one() {
     echo "########################################################################################################" >> "${LOG_FILE}"
@@ -1407,6 +1463,40 @@ option_five() {
     read -n 1 -s -r -p "                                    Press any key to return to the menu..." </dev/tty
 }
 
+option_six() {
+    echo "########################################################################################################" >> "${LOG_FILE}"
+    echo "MWDMA2 Kernel Patch:" >> "${LOG_FILE}"
+
+    echo
+    echo "  This patches the PS2 Linux kernel to use MWDMA2 instead of UDMA4"
+    echo "  for DMA transfers. Fixes write hangs on SCPH-7000x consoles"
+    echo "  using IDE→SD or IDE→SATA adapters."
+    echo
+    echo "  NOTE: This fixes the PSBBN boot hang, but game launching from"
+    echo "  the PSBBN menu may still freeze on 'Wait while loading' screen."
+    echo "  This is a separate issue under investigation (see PR #575)."
+    echo
+    read -p "  Apply MWDMA2 kernel patch? [y/N]: " confirm
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+        echo
+        echo "  Patch cancelled."
+        sleep 2
+        return 0
+    fi
+    echo
+
+    if [ ! -f "${STORAGE_DIR}/__system/p2lboot/vmlinux" ]; then
+        echo "  [!] Kernel not found at __system/p2lboot/vmlinux" | tee -a "${LOG_FILE}"
+        echo "  Make sure PSBBN partitions are mounted."
+        sleep 3
+        return 1
+    fi
+
+    patch_vmlinux_mwdma2 "${STORAGE_DIR}/__system/p2lboot/vmlinux"
+    echo
+    read -n 1 -s -r -p "                                    Press any key to return to the menu..." </dev/tty
+}
+
 EXTRAS_SPLASH() {
 clear
     cat << "EOF"
@@ -1435,6 +1525,8 @@ display_menu() {
                                     4) Change Screen Settings
 
                                     5) Clear Art & Icon Cache
+
+                                    6) Apply MWDMA2 Kernel Patch
 
                                     b) Back to Main Menu
 
@@ -1494,6 +1586,9 @@ while true; do
             ;;
         5)
             option_five
+            ;;
+        6)
+            option_six
             ;;
         b|B)
             break

--- a/scripts/Extras.sh
+++ b/scripts/Extras.sh
@@ -1464,6 +1464,7 @@ option_five() {
 }
 
 option_six() {
+    clear
     echo "########################################################################################################" >> "${LOG_FILE}"
     echo "MWDMA2 Kernel Patch:" >> "${LOG_FILE}"
 
@@ -1483,16 +1484,15 @@ option_six() {
         sleep 2
         return 0
     fi
-    echo
-
-    if [ ! -f "${STORAGE_DIR}/__system/p2lboot/vmlinux" ]; then
-        echo "  [!] Kernel not found at __system/p2lboot/vmlinux" | tee -a "${LOG_FILE}"
-        echo "  Make sure PSBBN partitions are mounted."
-        sleep 3
-        return 1
-    fi
+    
+    APA_PARTITIONS=("__system" )
+    mapper_probe && \
+    mount_pfs || return 1
+    sleep 2
 
     patch_vmlinux_mwdma2 "${STORAGE_DIR}/__system/p2lboot/vmlinux"
+    clean_up || return 1
+    
     echo
     read -n 1 -s -r -p "                                    Press any key to return to the menu..." </dev/tty
 }

--- a/scripts/PSBBN-Installer.sh
+++ b/scripts/PSBBN-Installer.sh
@@ -99,6 +99,23 @@ done
 
 if [ "$MODE" = "install" ]; then
     LOG_FILE="${TOOLKIT_PATH}/logs/PSBBN-installer.log"
+    # Prompt for SCPH-7000x adapter options
+    echo
+    echo "  ┌─────────────────────────────────────────────────────────┐"
+    echo "  │  SCPH-7000x / IDE→SD adapter options                    │"
+    echo "  │  Fixes for third-party HDD adapters and SD cards         │"
+    echo "  │  Only enable if using IDE→SD, IDE→SATA, or similar      │"
+    echo "  └─────────────────────────────────────────────────────────┘"
+    echo
+    read -p "  Create __boot partition for modchip DEV2 auto-boot?  [y/N]: " BOOT_MODE
+    if [[ "$BOOT_MODE" =~ ^[Yy]$ ]]; then
+        BOOT_PARTITION=1
+    fi
+    read -p "  Enable MWDMA2 kernel patch (fixes UDMA write hangs)? [y/N]: " SD_MODE
+    if [[ "$SD_MODE" =~ ^[Yy]$ ]]; then
+        SD_CARD_MWDMA2=1
+    fi
+    [ "$BOOT_PARTITION" = "1" ] || [ "$SD_CARD_MWDMA2" = "1" ] && echo
 else
     LOG_FILE="${TOOLKIT_PATH}/logs/update.log"
 fi
@@ -112,6 +129,9 @@ version_le() { # returns 0 (true) if $1 < $2
 if [ "$MODE" = "install" ]; then
     LINUX_PARTITIONS=("__linux.1" "__linux.4" "__linux.5" "__linux.6" "__linux.7" "__linux.8" "__linux.9" )
     PFS_PARTITIONS=("__contents" "__system" "__sysconf" "__common" )
+    if [ "$BOOT_PARTITION" = "1" ]; then
+        PFS_PARTITIONS+=("__boot")
+    fi
 fi
 
 error_msg() {
@@ -207,6 +227,62 @@ exit_script() {
     if [[ -n "$path_arg" ]]; then
         cp "${LOG_FILE}" "${path_arg}" > /dev/null 2>&1
     fi
+}
+
+# Patch vmlinux kernel to use MWDMA2 instead of UDMA4 for DMA
+# Fixes IDE→SD/SATA adapters on SCPH-7000x that fail on UDMA writes
+patch_vmlinux_mwdma2() {
+    local vmlinux="$1"
+    if [ ! -f "$vmlinux" ]; then
+        echo "  [!] vmlinux not found at $vmlinux" | tee -a "${LOG_FILE}"
+        return 1
+    fi
+    echo "  Patching kernel for MWDMA2 (SD card mode)..." | tee -a "${LOG_FILE}"
+    python3 -c "
+import struct, sys, subprocess
+with open('$vmlinux', 'rb+') as f:
+    data = f.read()
+    sym_addr = None
+    # Try nm first, then readelf
+    for cmd in (['nm', '$vmlinux'], ['readelf', '-s', '$vmlinux']):
+        try:
+            out = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode()
+            for line in out.split('\\n'):
+                if 'ide_config_drive_speed' in line:
+                    parts = line.split()
+                    if parts:
+                        try: sym_addr = int(parts[0], 16); break
+                        except: pass
+            if sym_addr: break
+        except: pass
+    if sym_addr:
+        jal = (0x0C << 26) | ((sym_addr >> 2) & 0x3FFFFFF)
+        jal_bytes = struct.pack('<I', jal)
+        old_li = struct.pack('<I', 0x24050044)
+        pattern = jal_bytes + old_li
+        idx = data.find(pattern)
+        if idx >= 0:
+            data = bytearray(data)
+            data[idx + 4] = 0x22
+            f.seek(0); f.write(data); f.truncate()
+            print(f'Patched at file offset 0x{idx+4:x}')
+            sys.exit(0)
+    # Fallback: find JAL + li a1,0x44
+    old_li = struct.pack('<I', 0x24050044)
+    idx = data.find(old_li)
+    while idx >= 0:
+        if idx >= 4:
+            prev = struct.unpack_from('<I', data, idx - 4)[0]
+            if (prev >> 26) == 0x03:
+                data = bytearray(data)
+                data[idx] = 0x22
+                f.seek(0); f.write(data); f.truncate()
+                print(f'Patched at file offset 0x{idx:x}')
+                sys.exit(0)
+        idx = data.find(old_li, idx + 1)
+    print('Pattern not found')
+    sys.exit(1)
+" 2>> "${LOG_FILE}" && echo "  [OK] Kernel patched for MWDMA2" | tee -a "${LOG_FILE}" || echo "  [!] Kernel patch failed - may already be patched" | tee -a "${LOG_FILE}"
 }
 
 get_latest_file() {
@@ -939,6 +1015,9 @@ if [ "$MODE" = "install" ]; then
 
     COMMANDS="device ${DEVICE}\n"
     COMMANDS+="initialize yes\n"
+    if [ "$BOOT_PARTITION" = "1" ]; then
+        COMMANDS+="mkpart __boot 128M PFS\n"
+    fi
     COMMANDS+="mkpart __linux.1 512M EXT2\n"
     COMMANDS+="mkpart __linux.2 128M EXT2SWAP\n"
     COMMANDS+="mkpart __linux.4 512M EXT2\n"
@@ -1227,6 +1306,12 @@ if [ "$OSD_UPDATE" != "no" ]; then
     cp -f "${ASSETS_DIR}/osdmenu/"{hosdmenu.elf,version.txt} "${STORAGE_DIR}/__system/osdmenu/" 2>> "${LOG_FILE}" || error_msg "Failed to copy hosdmenu.elf."
 fi
 
+# Install Dev2 bootloader for auto-boot from __boot partition (if requested)
+if [ "$BOOT_PARTITION" = "1" ] && [ -f "${ASSETS_DIR}/modbo_dev2_boot.elf" ]; then
+    cp -f "${ASSETS_DIR}/modbo_dev2_boot.elf" "${STORAGE_DIR}/__boot/BOOT.ELF" 2>> "${LOG_FILE}" || echo "  [!] Failed to copy Dev2 bootloader." | tee -a "${LOG_FILE}"
+    echo "  [OK] Dev2 bootloader installed to __boot partition." | tee -a "${LOG_FILE}"
+fi
+
 # Check if OSDMBR.CNF exists
 if [ ! -f "${STORAGE_DIR}/__sysconf/osdmenu/OSDMBR.CNF" ]; then
     if sudo "${HDL_DUMP}" toc ${DEVICE} | grep -q "__linux.3"; then
@@ -1386,6 +1471,11 @@ if [ "$OS" = "PSBBN" ] && [ "$MODE" = "update" ]; then
     error_msg "Failed to update $SYSCONF_XML";
 
     sudo cp -f "${SYSCONF_XML}" "${STORAGE_DIR}/__linux.4/bn/script/utility/sysconf.xml" || error_msg "Failed to replace sysconf.xml."
+fi
+
+# Apply SD card MWDMA2 kernel patch if selected
+if [ "$SD_CARD_MWDMA2" = "1" ] && [ -f "${STORAGE_DIR}/__system/p2lboot/vmlinux" ]; then
+    patch_vmlinux_mwdma2 "${STORAGE_DIR}/__system/p2lboot/vmlinux"
 fi
 
 UNMOUNT_ALL

--- a/scripts/PSBBN-Installer.sh
+++ b/scripts/PSBBN-Installer.sh
@@ -99,23 +99,8 @@ done
 
 if [ "$MODE" = "install" ]; then
     LOG_FILE="${TOOLKIT_PATH}/logs/PSBBN-installer.log"
-    # Prompt for SCPH-7000x adapter options
-    echo
-    echo "  ┌─────────────────────────────────────────────────────────┐"
-    echo "  │  SCPH-7000x / IDE→SD adapter options                    │"
-    echo "  │  Fixes for third-party HDD adapters and SD cards         │"
-    echo "  │  Only enable if using IDE→SD, IDE→SATA, or similar      │"
-    echo "  └─────────────────────────────────────────────────────────┘"
-    echo
-    read -p "  Create __boot partition for modchip DEV2 auto-boot?  [y/N]: " BOOT_MODE
-    if [[ "$BOOT_MODE" =~ ^[Yy]$ ]]; then
-        BOOT_PARTITION=1
-    fi
-    read -p "  Enable MWDMA2 kernel patch (fixes UDMA write hangs)? [y/N]: " SD_MODE
-    if [[ "$SD_MODE" =~ ^[Yy]$ ]]; then
-        SD_CARD_MWDMA2=1
-    fi
-    [ "$BOOT_PARTITION" = "1" ] || [ "$SD_CARD_MWDMA2" = "1" ] && echo
+    # Always create a small __boot partition (harmless, usable for modchip DEV2)
+    BOOT_PARTITION=1
 else
     LOG_FILE="${TOOLKIT_PATH}/logs/update.log"
 fi
@@ -128,10 +113,7 @@ version_le() { # returns 0 (true) if $1 < $2
 
 if [ "$MODE" = "install" ]; then
     LINUX_PARTITIONS=("__linux.1" "__linux.4" "__linux.5" "__linux.6" "__linux.7" "__linux.8" "__linux.9" )
-    PFS_PARTITIONS=("__contents" "__system" "__sysconf" "__common" )
-    if [ "$BOOT_PARTITION" = "1" ]; then
-        PFS_PARTITIONS+=("__boot")
-    fi
+    PFS_PARTITIONS=("__contents" "__system" "__sysconf" "__common" "__boot" )
 fi
 
 error_msg() {
@@ -227,62 +209,6 @@ exit_script() {
     if [[ -n "$path_arg" ]]; then
         cp "${LOG_FILE}" "${path_arg}" > /dev/null 2>&1
     fi
-}
-
-# Patch vmlinux kernel to use MWDMA2 instead of UDMA4 for DMA
-# Fixes IDE→SD/SATA adapters on SCPH-7000x that fail on UDMA writes
-patch_vmlinux_mwdma2() {
-    local vmlinux="$1"
-    if [ ! -f "$vmlinux" ]; then
-        echo "  [!] vmlinux not found at $vmlinux" | tee -a "${LOG_FILE}"
-        return 1
-    fi
-    echo "  Patching kernel for MWDMA2 (SD card mode)..." | tee -a "${LOG_FILE}"
-    python3 -c "
-import struct, sys, subprocess
-with open('$vmlinux', 'rb+') as f:
-    data = f.read()
-    sym_addr = None
-    # Try nm first, then readelf
-    for cmd in (['nm', '$vmlinux'], ['readelf', '-s', '$vmlinux']):
-        try:
-            out = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode()
-            for line in out.split('\\n'):
-                if 'ide_config_drive_speed' in line:
-                    parts = line.split()
-                    if parts:
-                        try: sym_addr = int(parts[0], 16); break
-                        except: pass
-            if sym_addr: break
-        except: pass
-    if sym_addr:
-        jal = (0x0C << 26) | ((sym_addr >> 2) & 0x3FFFFFF)
-        jal_bytes = struct.pack('<I', jal)
-        old_li = struct.pack('<I', 0x24050044)
-        pattern = jal_bytes + old_li
-        idx = data.find(pattern)
-        if idx >= 0:
-            data = bytearray(data)
-            data[idx + 4] = 0x22
-            f.seek(0); f.write(data); f.truncate()
-            print(f'Patched at file offset 0x{idx+4:x}')
-            sys.exit(0)
-    # Fallback: find JAL + li a1,0x44
-    old_li = struct.pack('<I', 0x24050044)
-    idx = data.find(old_li)
-    while idx >= 0:
-        if idx >= 4:
-            prev = struct.unpack_from('<I', data, idx - 4)[0]
-            if (prev >> 26) == 0x03:
-                data = bytearray(data)
-                data[idx] = 0x22
-                f.seek(0); f.write(data); f.truncate()
-                print(f'Patched at file offset 0x{idx:x}')
-                sys.exit(0)
-        idx = data.find(old_li, idx + 1)
-    print('Pattern not found')
-    sys.exit(1)
-" 2>> "${LOG_FILE}" && echo "  [OK] Kernel patched for MWDMA2" | tee -a "${LOG_FILE}" || echo "  [!] Kernel patch failed - may already be patched" | tee -a "${LOG_FILE}"
 }
 
 get_latest_file() {
@@ -1015,9 +941,7 @@ if [ "$MODE" = "install" ]; then
 
     COMMANDS="device ${DEVICE}\n"
     COMMANDS+="initialize yes\n"
-    if [ "$BOOT_PARTITION" = "1" ]; then
-        COMMANDS+="mkpart __boot 128M PFS\n"
-    fi
+    COMMANDS+="mkpart __boot 8M PFS\n"
     COMMANDS+="mkpart __linux.1 512M EXT2\n"
     COMMANDS+="mkpart __linux.2 128M EXT2SWAP\n"
     COMMANDS+="mkpart __linux.4 512M EXT2\n"
@@ -1306,11 +1230,7 @@ if [ "$OSD_UPDATE" != "no" ]; then
     cp -f "${ASSETS_DIR}/osdmenu/"{hosdmenu.elf,version.txt} "${STORAGE_DIR}/__system/osdmenu/" 2>> "${LOG_FILE}" || error_msg "Failed to copy hosdmenu.elf."
 fi
 
-# Install Dev2 bootloader for auto-boot from __boot partition (if requested)
-if [ "$BOOT_PARTITION" = "1" ] && [ -f "${ASSETS_DIR}/modbo_dev2_boot.elf" ]; then
-    cp -f "${ASSETS_DIR}/modbo_dev2_boot.elf" "${STORAGE_DIR}/__boot/BOOT.ELF" 2>> "${LOG_FILE}" || echo "  [!] Failed to copy Dev2 bootloader." | tee -a "${LOG_FILE}"
-    echo "  [OK] Dev2 bootloader installed to __boot partition." | tee -a "${LOG_FILE}"
-fi
+# __boot partition is created automatically; users copy their own bootloader if needed
 
 # Check if OSDMBR.CNF exists
 if [ ! -f "${STORAGE_DIR}/__sysconf/osdmenu/OSDMBR.CNF" ]; then
@@ -1473,10 +1393,7 @@ if [ "$OS" = "PSBBN" ] && [ "$MODE" = "update" ]; then
     sudo cp -f "${SYSCONF_XML}" "${STORAGE_DIR}/__linux.4/bn/script/utility/sysconf.xml" || error_msg "Failed to replace sysconf.xml."
 fi
 
-# Apply SD card MWDMA2 kernel patch if selected
-if [ "$SD_CARD_MWDMA2" = "1" ] && [ -f "${STORAGE_DIR}/__system/p2lboot/vmlinux" ]; then
-    patch_vmlinux_mwdma2 "${STORAGE_DIR}/__system/p2lboot/vmlinux"
-fi
+# MWDMA2 kernel patch is available in the Extras menu for IDE→SD adapter users
 
 UNMOUNT_ALL
 


### PR DESCRIPTION
## Summary

Adds two optional features for SCPH-7000x and third-party HDD adapter users, both opt-in during installation:

### 1. Optional __boot partition for modchip DEV2 auto-boot

Creates a 128MB PFS __boot partition during installation, placed right after __mbr. Users can place a compatible DEV2 bootloader as scripts/assets/modbo_dev2_boot.elf before running the installer. I myself use a Modbo 5.0, so it's very convenient, instead of searching for and buying MG memory card. Will be uploading the code shortly, as soon as I am done with debugging the code

### 2. Optional MWDMA2 kernel patch for IDE→SD/SATA adapters

Adds patch_vmlinux_mwdma2() function that automatically binary-patches the PS2 Linux kernel to use MWDMA2 instead of UDMA4 for DMA transfers. Fixes write failures on SCPH-7000x using IDE→SD or IDE→SATA adapters.

Both options are presented in an interactive prompt during installation and default to No — zero changes for official Sony Network Adapter users.

### Testing

Tested on SCPH-7000x with IDE→SD adapter, 128GB SD card, PSBBN Definitive v4.2.0.

### History

Did some debugging session 3 years ago on why wLE-ISR (generally wLE/uLE) won't write files succesfully after I installed sd-card adapter, turned out if you switch ps2atad.irx driver to MWDMA2 - it worked :) Tried the trick on PSBBN vmlinux - seems to have worked. Enjoy!