### PR TITLE
[FEAT] Interactive game selector with danger-colored progress bar 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ gamepath.cfg
 media.cfg
 bnupdate.tar.gz
 path.cfg
+**/__pycache__/**
+**.pyc
+icons/**

--- a/PSBBN-Definitive-Patch.sh
+++ b/PSBBN-Definitive-Patch.sh
@@ -334,6 +334,7 @@ check_dep(){
         check_python_pkg icu
         check_python_pkg pykakasi
         check_python_pkg PIL
+        check_python_pkg textual
     fi
 
     if { ldconfig -p 2>/dev/null | grep -q "libfuse.so.2"; } || pkg-config --exists fuse 2>/dev/null; then

--- a/scripts/Game-Installer.sh
+++ b/scripts/Game-Installer.sh
@@ -1736,13 +1736,20 @@ echo "     - Installs new games and apps found in the games folder on your PC."
 echo "     - Scans for newly added or removed games and apps, then updates the game list"
 echo "       in the PSBBN Game Collection and HDD-OSD accordingly."
 echo
+echo "  3) Select Specific Games:"
+echo
+echo "     - Synchronizes all games from your PC to the PS2 drive."
+echo "     - After synchronization, opens an interactive selector to choose"
+echo "       individual games for installation."
+echo
 
 while true; do
-    read -p "Enter 1 or 2: " choice
+    read -p "Enter 1, 2, or 3: " choice
     case "$choice" in
         1) INSTALL_TYPE="sync" DESC1="Synchronize"; break ;;
         2) INSTALL_TYPE="copy" DESC1="Add Games and Apps"; break ;;
-        *) echo; echo "Invalid choice. Please enter 1 or 2." ;;
+        3) INSTALL_TYPE="sync" SELECT_SPECIFIC="y" DESC1="Select Specific Games"; break ;;
+        *) echo; echo "Invalid choice. Please enter 1, 2, or 3." ;;
     esac
 done
 
@@ -2026,12 +2033,164 @@ fi
 
 convert_bin
 
+# ═══════════════════════════════════════════════════════════════
+# Game selector
+# ═══════════════════════════════════════════════════════════════
+
+if [[ "$SELECT_SPECIFIC" == "y" ]]; then
+    GAME_SELECTOR="y"
+elif [[ -s "${PS1_LIST}" || -s "${PS2_LIST}" ]]; then
+    SPLASH
+    echo "Would you like to select specific games to install?"
+    echo
+    echo "This scans your local games folder and opens an interactive"
+    echo "selector (keyboard required) where you can choose individual"
+    echo "games with checkboxes."
+    echo
+    while true; do
+        read -p "Yes or No (y/n): " choice
+        case "$choice" in
+            [Yy]) GAME_SELECTOR="y"; break ;;
+            [Nn]) GAME_SELECTOR="n"; break ;;
+            *) echo "Please enter y or n." ;;
+        esac
+    done
+fi
+
+run_game_selector() {
+    if ! "${SCRIPTS_DIR}/venv/bin/python3" -c "import textual" 2>/dev/null || \
+       ! "${SCRIPTS_DIR}/venv/bin/python3" -c "import tkinter" 2>/dev/null; then
+        echo | tee -a "${LOG_FILE}"
+        if ! "${SCRIPTS_DIR}/venv/bin/python3" -c "import textual" 2>/dev/null; then
+            echo "Textual not installed. Install with: pip install textual" | tee -a "${LOG_FILE}"
+        fi
+        if ! "${SCRIPTS_DIR}/venv/bin/python3" -c "import tkinter" 2>/dev/null; then
+            echo "tkinter not installed. Install system package: python3-tk (apt) / python3-tkinter (dnf) / tk (pacman)" | tee -a "${LOG_FILE}"
+        fi
+        echo "Proceeding with all games." | tee -a "${LOG_FILE}"
+        return 1
+    fi
+
+    local disk_total_gb=0
+    if mountpoint -q "${OPL}" 2>/dev/null; then
+        disk_total_gb=$(df -BG --output=size "${OPL}" | tail -n 1 | sed 's/G//' | tr -d ' ')
+    fi
+    if [ -z "$disk_total_gb" ] || [ "$disk_total_gb" = "0" ]; then
+        echo "Could not determine disk size. Using default 0 GB." | tee -a "${LOG_FILE}"
+        disk_total_gb=0
+    fi
+
+    echo | tee -a "${LOG_FILE}"
+    echo "Launching interactive game selector in a new window (Disk: ${disk_total_gb} GB)..." | tee -a "${LOG_FILE}"
+
+    local selected_file="${SCRIPTS_DIR}/tmp/selected_games.list"
+    rm -f "$selected_file"
+
+    local TERM_EMULATOR=""
+    for cmd in konsole xterm gnome-terminal xfce4-terminal; do
+        if command -v "$cmd" >/dev/null 2>&1; then
+            TERM_EMULATOR="$cmd"
+            break
+        fi
+    done
+
+    if [ -z "$TERM_EMULATOR" ]; then
+        echo "No terminal emulator found. Proceeding with all games." | tee -a "${LOG_FILE}"
+        return 1
+    fi
+
+    local selector_cmd
+    printf -v selector_cmd '%s -u %s --games-dir %s --output %s --disk-total-gb %s' \
+        "${SCRIPTS_DIR}/venv/bin/python3" \
+        "${HELPER_DIR}/game-selector.py" \
+        "${GAMES_PATH}" \
+        "${selected_file}" \
+        "${disk_total_gb}"
+
+    local exit_code=0
+    case "$TERM_EMULATOR" in
+        konsole)
+            # -e waits for command to finish; auto-closes when done
+            "$TERM_EMULATOR" -e bash -c "$selector_cmd" 2>>"${LOG_FILE}"
+            exit_code=$?
+            ;;
+        gnome-terminal)
+            # --wait ensures we don't return until the child exits
+            "$TERM_EMULATOR" --wait -e bash -c "$selector_cmd" 2>>"${LOG_FILE}"
+            exit_code=$?
+            ;;
+        xfce4-terminal)
+            # --disable-server prevents forking via D-Bus
+            "$TERM_EMULATOR" --disable-server -e bash -c "$selector_cmd" 2>>"${LOG_FILE}"
+            exit_code=$?
+            ;;
+        *)
+            # xterm and others
+            "$TERM_EMULATOR" -e bash -c "$selector_cmd" 2>>"${LOG_FILE}"
+            exit_code=$?
+            ;;
+    esac
+
+    if [ $exit_code -eq 2 ]; then
+        echo "Game selection cancelled by user. Aborting." | tee -a "${LOG_FILE}"
+        exit 0
+    elif [ $exit_code -eq 0 ] && [ -s "$selected_file" ]; then
+        local selected_count
+        selected_count=$(wc -l < "$selected_file")
+        echo "[✓] ${selected_count} games selected." | tee -a "${LOG_FILE}"
+        cp "$selected_file" "${ALL_GAMES}"
+        GAME_SELECTOR="y"
+    else
+        if [ $exit_code -ne 0 ]; then
+            echo "Game selector failed (exit code: $exit_code)." | tee -a "${LOG_FILE}"
+        else
+            echo "No games selected. Keeping all games." | tee -a "${LOG_FILE}"
+        fi
+        GAME_SELECTOR="n"
+        return 1
+    fi
+    return 0
+}
+
+if [[ "$GAME_SELECTOR" == "y" ]]; then
+    rm -f "${ALL_GAMES}"
+    run_game_selector
+fi
+
+# Create rsync filter files from selected games
+SELECTED_CD=""
+SELECTED_DVD=""
+if [[ "$GAME_SELECTOR" == "y" && -s "${ALL_GAMES}" ]]; then
+    SELECTED_CD=$(mktemp)
+    SELECTED_DVD=$(mktemp)
+    awk -F'|' '$4 == "CD" { print $5 }' "${ALL_GAMES}" > "${SELECTED_CD}" 2>/dev/null
+    awk -F'|' '$4 == "DVD" { print $5 }' "${ALL_GAMES}" > "${SELECTED_DVD}" 2>/dev/null
+    echo "CD games selected: $(wc -l < "${SELECTED_CD}")" | tee -a "${LOG_FILE}"
+    echo "DVD games selected: $(wc -l < "${SELECTED_DVD}")" | tee -a "${LOG_FILE}"
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# Synchronize PS2 Games
+# ═══════════════════════════════════════════════════════════════
+
 if [ "$INSTALL_TYPE" = "sync" ]; then
-    cd=$(rsync -dL --dry-run --delete --ignore-existing --itemize-changes --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/CD/" "${OPL}/CD/")
-    dvd=$(rsync -dL --dry-run --delete --ignore-existing --itemize-changes --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/DVD/" "${OPL}/DVD/")
+    if [[ "$GAME_SELECTOR" == "y" ]]; then
+        cd=""
+        dvd=""
+        [[ -s "${SELECTED_CD}" ]] && cd=$(rsync -dL --dry-run --delete --itemize-changes --files-from="${SELECTED_CD}" "${GAMES_PATH}/CD/" "${OPL}/CD/" 2>>"${LOG_FILE}")
+        [[ -s "${SELECTED_DVD}" ]] && dvd=$(rsync -dL --dry-run --delete --itemize-changes --files-from="${SELECTED_DVD}" "${GAMES_PATH}/DVD/" "${OPL}/DVD/" 2>>"${LOG_FILE}")
+    else
+        cd=$(rsync -dL --dry-run --delete --ignore-existing --itemize-changes --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/CD/" "${OPL}/CD/")
+        dvd=$(rsync -dL --dry-run --delete --ignore-existing --itemize-changes --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/DVD/" "${OPL}/DVD/")
+    fi
 elif [ "$INSTALL_TYPE" = "copy" ]; then
-    cd=$(rsync -dL --dry-run --ignore-existing --itemize-changes --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/CD/" "${OPL}/CD/")
-    dvd=$(rsync -dL --dry-run --ignore-existing --itemize-changes --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/DVD/" "${OPL}/DVD/")
+    if [[ "$GAME_SELECTOR" == "y" ]]; then
+        cd=$(rsync -dL --dry-run --ignore-existing --itemize-changes --files-from="${SELECTED_CD}" "${GAMES_PATH}/CD/" "${OPL}/CD/" 2>>"${LOG_FILE}")
+        dvd=$(rsync -dL --dry-run --ignore-existing --itemize-changes --files-from="${SELECTED_DVD}" "${GAMES_PATH}/DVD/" "${OPL}/DVD/" 2>>"${LOG_FILE}")
+    else
+        cd=$(rsync -dL --dry-run --ignore-existing --itemize-changes --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/CD/" "${OPL}/CD/")
+        dvd=$(rsync -dL --dry-run --ignore-existing --itemize-changes --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/DVD/" "${OPL}/DVD/")
+    fi
 fi
 
 if [ -n "$cd" ] || [ -n "$dvd" ]; then
@@ -2041,16 +2200,44 @@ if [ -n "$cd" ] || [ -n "$dvd" ]; then
     echo "Available space: $available_mb MB" | tee -a "${LOG_FILE}"
     echo | tee -a "${LOG_FILE}"
     if [ "$INSTALL_TYPE" = "sync" ]; then
-        rsync -dL --progress --delete --ignore-existing --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/CD/" "${OPL}/CD/" 2>>"${LOG_FILE}" | tee -a "${LOG_FILE}"
-        cd_status=${PIPESTATUS[0]}
-        rsync -dL --progress --delete --ignore-existing --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/DVD/" "${OPL}/DVD/" 2>>"${LOG_FILE}" | tee -a "${LOG_FILE}"
-        dvd_status=${PIPESTATUS[0]}
+        if [[ "$GAME_SELECTOR" == "y" ]]; then
+            cd_status=0; dvd_status=0
+            if [[ -s "${SELECTED_CD}" ]]; then
+                rsync -dL --progress --delete --files-from="${SELECTED_CD}" "${GAMES_PATH}/CD/" "${OPL}/CD/" 2>>"${LOG_FILE}"
+                cd_status=$?
+                echo "CD games synced." | tee -a "${LOG_FILE}"
+            fi
+            if [[ -s "${SELECTED_DVD}" ]]; then
+                rsync -dL --progress --delete --files-from="${SELECTED_DVD}" "${GAMES_PATH}/DVD/" "${OPL}/DVD/" 2>>"${LOG_FILE}"
+                dvd_status=$?
+                echo "DVD games synced." | tee -a "${LOG_FILE}"
+            fi
+        else
+            rsync -dL --progress --delete --ignore-existing --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/CD/" "${OPL}/CD/" 2>>"${LOG_FILE}" | tee -a "${LOG_FILE}"
+            cd_status=${PIPESTATUS[0]}
+            rsync -dL --progress --delete --ignore-existing --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/DVD/" "${OPL}/DVD/" 2>>"${LOG_FILE}" | tee -a "${LOG_FILE}"
+            dvd_status=${PIPESTATUS[0]}
+        fi
         ps2_rsync_check Synced
     else
-        rsync -dL --progress --ignore-existing --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/CD/" "${OPL}/CD/" 2>>"${LOG_FILE}" | tee -a "${LOG_FILE}"
-        cd_status=${PIPESTATUS[0]}
-        rsync -dL --progress --ignore-existing --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/DVD/" "${OPL}/DVD/" 2>>"${LOG_FILE}" | tee -a "${LOG_FILE}"
-        dvd_status=${PIPESTATUS[0]}
+        if [[ "$GAME_SELECTOR" == "y" ]]; then
+            cd_status=0; dvd_status=0
+            if [[ -s "${SELECTED_CD}" ]]; then
+                rsync -dL --progress --ignore-existing --files-from="${SELECTED_CD}" "${GAMES_PATH}/CD/" "${OPL}/CD/" 2>>"${LOG_FILE}"
+                cd_status=$?
+                echo "CD games synced." | tee -a "${LOG_FILE}"
+            fi
+            if [[ -s "${SELECTED_DVD}" ]]; then
+                rsync -dL --progress --ignore-existing --files-from="${SELECTED_DVD}" "${GAMES_PATH}/DVD/" "${OPL}/DVD/" 2>>"${LOG_FILE}"
+                dvd_status=$?
+                echo "DVD games synced." | tee -a "${LOG_FILE}"
+            fi
+        else
+            rsync -dL --progress --ignore-existing --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/CD/" "${OPL}/CD/" 2>>"${LOG_FILE}" | tee -a "${LOG_FILE}"
+            cd_status=${PIPESTATUS[0]}
+            rsync -dL --progress --ignore-existing --include='*.iso' --include='*.ISO' --include='*.zso' --include='*.ZSO' --exclude='.*' --exclude='*' "${GAMES_PATH}/DVD/" "${OPL}/DVD/" 2>>"${LOG_FILE}" | tee -a "${LOG_FILE}"
+            dvd_status=${PIPESTATUS[0]}
+        fi
         ps2_rsync_check Copied
     fi
 else
@@ -2107,13 +2294,15 @@ if [[ ! -s "${PS1_LIST}" && ! -s "${PS2_LIST}" ]] && find "${GAMES_PATH}/CD" "${
     error_msg "Error" "Failed to create games list."
 fi
 
-if [[ -s "${PS1_LIST}" ]] && [[ ! -s "${PS2_LIST}" ]]; then
-    { cat "${PS1_LIST}" > "${ALL_GAMES}"; } 2>> "${LOG_FILE}"
-elif [[ ! -s "${PS1_LIST}" ]] && [[ -s "${PS2_LIST}" ]]; then
-    { cat "${PS2_LIST}" >> "${ALL_GAMES}"; } 2>> "${LOG_FILE}"
-elif [[ -s "${PS1_LIST}" ]] && [[ -s "${PS2_LIST}" ]]; then
-    { cat "${PS1_LIST}" > "${ALL_GAMES}"; } 2>> "${LOG_FILE}"
-    { cat "${PS2_LIST}" >> "${ALL_GAMES}"; } 2>> "${LOG_FILE}"
+if [[ "$GAME_SELECTOR" != "y" ]]; then
+    if [[ -s "${PS1_LIST}" ]] && [[ ! -s "${PS2_LIST}" ]]; then
+        { cat "${PS1_LIST}" > "${ALL_GAMES}"; } 2>> "${LOG_FILE}"
+    elif [[ ! -s "${PS1_LIST}" ]] && [[ -s "${PS2_LIST}" ]]; then
+        { cat "${PS2_LIST}" >> "${ALL_GAMES}"; } 2>> "${LOG_FILE}"
+    elif [[ -s "${PS1_LIST}" ]] && [[ -s "${PS2_LIST}" ]]; then
+        { cat "${PS1_LIST}" > "${ALL_GAMES}"; } 2>> "${LOG_FILE}"
+        { cat "${PS2_LIST}" >> "${ALL_GAMES}"; } 2>> "${LOG_FILE}"
+    fi
 fi
 
 rm -f "${OPL}/ps1.list"

--- a/scripts/Game-Installer.sh
+++ b/scripts/Game-Installer.sh
@@ -2061,13 +2061,11 @@ run_game_selector() {
     if ! "${SCRIPTS_DIR}/venv/bin/python3" -c "import textual" 2>/dev/null || \
        ! "${SCRIPTS_DIR}/venv/bin/python3" -c "import tkinter" 2>/dev/null; then
         echo | tee -a "${LOG_FILE}"
-        if ! "${SCRIPTS_DIR}/venv/bin/python3" -c "import textual" 2>/dev/null; then
-            echo "Textual not installed. Install with: pip install textual" | tee -a "${LOG_FILE}"
-        fi
-        if ! "${SCRIPTS_DIR}/venv/bin/python3" -c "import tkinter" 2>/dev/null; then
-            echo "tkinter not installed. Install system package: python3-tk (apt) / python3-tkinter (dnf) / tk (pacman)" | tee -a "${LOG_FILE}"
-        fi
-        echo "Proceeding with all games." | tee -a "${LOG_FILE}"
+        echo "Missing game selector dependencies. Install with:" | tee -a "${LOG_FILE}"
+        echo "  pip install textual" | tee -a "${LOG_FILE}"
+        echo "  sudo apt install python3-tk   (Debian/Ubuntu)" | tee -a "${LOG_FILE}"
+        echo "  sudo dnf install python3-tkinter (Fedora)" | tee -a "${LOG_FILE}"
+        echo "  sudo pacman -S tk             (Arch)" | tee -a "${LOG_FILE}"
         return 1
     fi
 
@@ -2142,12 +2140,11 @@ run_game_selector() {
         GAME_SELECTOR="y"
     else
         if [ $exit_code -ne 0 ]; then
-            echo "Game selector failed (exit code: $exit_code)." | tee -a "${LOG_FILE}"
+            echo "Game selector failed (exit code: $exit_code). Aborting." | tee -a "${LOG_FILE}"
         else
-            echo "No games selected. Keeping all games." | tee -a "${LOG_FILE}"
+            echo "No games selected. Aborting." | tee -a "${LOG_FILE}"
         fi
-        GAME_SELECTOR="n"
-        return 1
+        exit 0
     fi
     return 0
 }

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -95,20 +95,20 @@ if [ -x "$(command -v apt-get)" ]; then
         sudo dpkg --add-architecture i386
         i386="libc6:i386"
     fi
-    sudo apt-get -q update && sudo apt-get install -y axel imagemagick xxd python3 python3-venv python3-pip bc rsync curl zip unzip wget ffmpeg lvm2 libfuse2 dosfstools e2fsprogs libc-bin exfatprogs exfat-fuse util-linux fdisk parted bchunk build-essential libicu-dev pkg-config ffmpegthumbnailer binfmt-support unrar-free $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo apt-get -q update && sudo apt-get install -y axel imagemagick xxd python3 python3-venv python3-pip python3-tk bc rsync curl zip unzip wget ffmpeg lvm2 libfuse2 dosfstools e2fsprogs libc-bin exfatprogs exfat-fuse util-linux fdisk parted bchunk build-essential libicu-dev pkg-config ffmpegthumbnailer binfmt-support unrar-free $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Fedora-based system, do this instead
 elif [ -x "$(command -v dnf)" ]; then
     if [[ "$arch" = "x86_64" ]]; then
         i386="glibc.i686"
     fi
     sudo dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm 2>&1 | tee -a "${LOG_FILE}"
-    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl zip unzip wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer unrar-free $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip python3-tkinter bc rsync curl zip unzip wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer unrar-free $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Arch-based system, do this instead
 elif [ -x "$(command -v pacman)" ]; then
     if [[ "$arch" = "x86_64" ]]; then
         i386="lib32-glibc"
     fi
-    sudo pacman -S --needed --noconfirm axel imagemagick xxd python pyenv python-pip bc rsync curl zip unzip wget ffmpeg lvm2 fuse2 dosfstools e2fsprogs glibc exfatprogs util-linux parted bchunk base-devel icu pkgconf ffmpegthumbnailer unrar-free $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo pacman -S --needed --noconfirm axel imagemagick xxd python tk pyenv python-pip bc rsync curl zip unzip wget ffmpeg lvm2 fuse2 dosfstools e2fsprogs glibc exfatprogs util-linux parted bchunk base-devel icu pkgconf ffmpegthumbnailer unrar-free $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     error_msg "Running in Nix environment - packages should be provided by flake and setup should not be run."
 else
@@ -125,7 +125,7 @@ fi
 (
     python3 -m venv scripts/venv >> "${LOG_FILE}" 2>&1 || error_msg "Failed to create Python virtual environment."
     source scripts/venv/bin/activate || error_msg "Failed to activate the Python virtual environment."
-    pip install lz4 natsort mutagen tqdm PyICU pykakasi pillow >> "${LOG_FILE}" || error_msg "Failed to install Python dependencies."
+    pip install lz4 natsort mutagen tqdm PyICU pykakasi pillow textual >> "${LOG_FILE}" || error_msg "Failed to install Python dependencies."
     deactivate
 ) &
 PID=$!

--- a/scripts/helper/game-selector-ng.py
+++ b/scripts/helper/game-selector-ng.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+#
+# Game Selector NG - Alternative GUI using tkinter
+# Copyright (C) 2024-2026 CosmicScale
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Alternative game selector with tkinter GUI.
+
+Same functionality as game-selector.py (Textual TUI), using the
+same game-scanning engine imported from that module.
+Requires no external dependencies beyond Python stdlib + lz4.
+"""
+
+import importlib.util
+import sys
+import argparse
+from pathlib import Path
+import tkinter as tk
+from tkinter import ttk
+
+# ── Import engine from sibling game-selector.py ──────────────────────────
+_ENGINE_PATH = Path(__file__).resolve().parent / "game-selector.py"
+_SPEC = importlib.util.spec_from_file_location("_gs_engine", _ENGINE_PATH)
+_ENGINE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_ENGINE)
+
+GameEntry = _ENGINE.GameEntry
+scan_games = _ENGINE.scan_games
+_load_titles_db = _ENGINE._load_titles_db
+_load_games_from_lists = _ENGINE._load_games_from_lists
+
+
+# ── tkinter GUI ──────────────────────────────────────────────────────────
+
+class GameSelectorNG:
+    def __init__(self, games, output_file=None, disk_total_gb=0.0):
+        self.games = games
+        self.output_file = output_file
+        self.disk_total_gb = disk_total_gb or 0.0
+        self.selected_indices: set[int] = set()
+        self._mapping: list[int] = []
+        self._rebuilding = False
+        self._visible_ps2 = 0
+        self._visible_ps1 = 0
+
+        self._dt_width = 5
+        self._id_width = max(len(g.game_id) for g in games) if games else 11
+
+        self.root = tk.Tk()
+        self.root.title("Game Selector NG")
+        self.root.configure(bg="#0f1117")
+        self.root.minsize(640, 300)
+        self.root.after(10, self._maximize)
+
+        self._setup_styles()
+        self._build_ui()
+        self._rebuild_list()
+        self._update_info()
+
+    def _maximize(self):
+        try:
+            self.root.state("zoomed")
+        except tk.TclError:
+            w = self.root.winfo_screenwidth()
+            h = self.root.winfo_screenheight()
+            self.root.geometry(f"{w}x{h}+0+0")
+
+    # ── helpers ──────────────────────────────────────────────────────
+
+    def _fmt_game_line(self, g):
+        prefix = "PS1" if g.disc_type == "POPS" else "PS2"
+        dt = f"[{prefix}]".ljust(self._dt_width)
+        sz = f"{g.size_gb:>6.2f} GB"
+        id_ = f"({g.game_id})".ljust(self._id_width + 2)
+        return f"{dt} \u2502 {sz} \u2502 {id_} \u2502 {g.title}"
+
+    # ── styles ───────────────────────────────────────────────────────
+
+    def _setup_styles(self):
+        style = ttk.Style()
+        style.theme_use("clam")
+
+        style.configure(".", background="#0f1117", foreground="#e2e4eb")
+        style.configure("TFrame", background="#0f1117")
+        style.configure("TLabel", background="#0f1117", foreground="#c0c4d0")
+        style.configure(
+            "TEntry",
+            fieldbackground="#1e2030",
+            foreground="#e2e4eb",
+            insertcolor="#e2e4eb",
+            borderwidth=0,
+        )
+        style.map("TEntry", fieldbackground=[("focus", "#282a36")])
+        for name, fg in [("Green.TButton", "#50fa7b"), ("Red.TButton", "#ff5555"),
+                         ("Success.TButton", "#50fa7b"), ("Danger.TButton", "#ff5555")]:
+            style.configure(
+                name,
+                background="#1a1c25",
+                foreground=fg,
+                borderwidth=0,
+                focuscolor="none",
+            )
+            style.map(name, background=[("active", "#282a36")])
+        style.configure(
+            "green.Horizontal.TProgressbar",
+            troughcolor="#1a1c25", background="#50fa7b", borderwidth=0,
+        )
+        style.configure(
+            "yellow.Horizontal.TProgressbar",
+            troughcolor="#1a1c25", background="#ffb86c", borderwidth=0,
+        )
+        style.configure(
+            "red.Horizontal.TProgressbar",
+            troughcolor="#1a1c25", background="#ff5555", borderwidth=0,
+        )
+
+    # ── UI construction ──────────────────────────────────────────────
+
+    def _build_ui(self):
+        # header
+        header = tk.Label(
+            self.root, text="Game Selector NG",
+            bg="#161820", fg="#868d9e", anchor="w", padx=10, pady=4,
+        )
+        header.pack(fill=tk.X)
+
+        # search toolbar
+        search_frame = tk.Frame(self.root, bg="#1a1c25")
+        search_frame.pack(fill=tk.X)
+
+        self.search_var = tk.StringVar()
+        search_entry = ttk.Entry(
+            search_frame, textvariable=self.search_var, style="TEntry"
+        )
+        search_entry.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(8, 4), pady=4)
+
+        ttk.Button(
+            search_frame, text="All", style="Green.TButton",
+            command=self._on_select_all,
+        ).pack(side=tk.LEFT, padx=1, pady=4)
+
+        ttk.Button(
+            search_frame, text="Clear", style="Red.TButton",
+            command=self._on_deselect_all,
+        ).pack(side=tk.LEFT, padx=(1, 8), pady=4)
+
+        self.search_var.trace_add("write", self._on_search)
+
+        # type / selection info
+        self.info_var = tk.StringVar()
+        tk.Label(
+            self.root, textvariable=self.info_var,
+            bg="#0f1117", fg="#c0c4d0", anchor="center", pady=2,
+        ).pack(fill=tk.X)
+
+        # game list
+        list_frame = tk.Frame(self.root, bg="#161820")
+        list_frame.pack(fill=tk.BOTH, expand=True, padx=8, pady=(0, 4))
+
+        self.listbox = tk.Listbox(
+            list_frame,
+            selectmode=tk.EXTENDED,
+            font=("Courier", 10),
+            bg="#161820", fg="#c0c4d0",
+            selectbackground="#282a36", selectforeground="#e2e4eb",
+            relief=tk.FLAT, borderwidth=0, highlightthickness=0,
+            activestyle="underline",
+        )
+        self.listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.listbox.bind("<<ListboxSelect>>", self._on_select)
+
+        scrollbar = ttk.Scrollbar(list_frame, orient=tk.VERTICAL, command=self.listbox.yview)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.listbox.configure(yscrollcommand=scrollbar.set)
+
+        # progress
+        progress_frame = tk.Frame(self.root, bg="#0f1117")
+        progress_frame.pack(fill=tk.X, padx=8, pady=(0, 4))
+
+        self.progress_text = tk.StringVar()
+        tk.Label(
+            progress_frame, textvariable=self.progress_text,
+            bg="#0f1117", fg="#c0c4d0", anchor="w",
+        ).pack(side=tk.LEFT)
+
+        self.progress_bar = ttk.Progressbar(
+            progress_frame, mode="determinate",
+        )
+        self.progress_bar.pack(side=tk.RIGHT, fill=tk.X, expand=True, padx=(8, 0))
+
+        # bottom buttons
+        btn_frame = tk.Frame(self.root, bg="#0f1117")
+        btn_frame.pack(fill=tk.X, padx=8, pady=(0, 8))
+
+        ttk.Button(
+            btn_frame, text="Confirm", style="Success.TButton",
+            command=self._on_confirm,
+        ).pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(0, 4))
+
+        ttk.Button(
+            btn_frame, text="Cancel", style="Danger.TButton",
+            command=self._on_cancel,
+        ).pack(side=tk.RIGHT, fill=tk.X, expand=True, padx=(4, 0))
+
+        # key bindings
+        self.root.bind("<Control-f>", lambda e: search_entry.focus_set())
+        self.root.bind("<Control-a>", lambda e: self._on_select_all())
+        self.root.bind("<Control-Shift-a>", lambda e: self._on_deselect_all())
+        self.root.bind("<Control-Shift-A>", lambda e: self._on_deselect_all())
+        self.root.bind("<Escape>", lambda e: self._on_cancel())
+        self.root.bind("<Return>", lambda e: self._on_confirm())
+
+    # ── list management ──────────────────────────────────────────────
+
+    def _rebuild_list(self, query=""):
+        self._rebuilding = True
+        q = query.strip().lower()
+        self._mapping.clear()
+        self.listbox.delete(0, tk.END)
+
+        self._visible_ps2 = 0
+        self._visible_ps1 = 0
+
+        for i, g in enumerate(self.games):
+            if q and q not in g.title.lower() and q not in g.game_id.lower():
+                continue
+            if g.disc_type in ("CD", "DVD"):
+                self._visible_ps2 += 1
+            else:
+                self._visible_ps1 += 1
+            self._mapping.append(i)
+            self.listbox.insert(tk.END, self._fmt_game_line(g))
+
+        self.listbox.selection_clear(0, tk.END)
+        for disp_idx, game_idx in enumerate(self._mapping):
+            if game_idx in self.selected_indices:
+                self.listbox.selection_set(disp_idx)
+
+        self._rebuilding = False
+        self._update_info()
+
+    # ── event handlers ───────────────────────────────────────────────
+
+    def _on_search(self, *_):
+        self._rebuild_list(self.search_var.get())
+
+    def _on_select(self, event=None):
+        if self._rebuilding:
+            return
+        selected: set[int] = set()
+        for disp_idx in self.listbox.curselection():
+            if disp_idx < len(self._mapping):
+                selected.add(self._mapping[disp_idx])
+        self.selected_indices = selected
+        self._update_info()
+
+    def _on_select_all(self):
+        self.selected_indices = set(range(len(self.games)))
+        self._rebuild_list(self.search_var.get())
+
+    def _on_deselect_all(self):
+        self.selected_indices.clear()
+        self._rebuild_list(self.search_var.get())
+
+    def _on_confirm(self):
+        chosen = [self.games[i] for i in sorted(self.selected_indices)]
+        if self.output_file:
+            with open(self.output_file, "w") as f:
+                for g in chosen:
+                    f.write(g.pipe_line + "\n")
+        else:
+            for g in chosen:
+                print(g.pipe_line)
+        self.root.quit()
+
+    def _on_cancel(self):
+        sys.exit(2)
+
+    # ── info / progress ──────────────────────────────────────────────
+
+    def _update_info(self):
+        sel = len(self.selected_indices)
+        total = len(self.games)
+        gb = sum(self.games[i].size_gb for i in self.selected_indices)
+
+        self.info_var.set(
+            f"PS2 ({self._visible_ps2})  \u2502  PS1 ({self._visible_ps1})"
+            f"  \u2502  {sel} / {total} games selected  \u00b7  {gb:.2f} GB"
+        )
+        self._update_progress()
+
+    def _update_progress(self):
+        sel_gb = sum(self.games[i].size_gb for i in self.selected_indices)
+        sel_gb = min(sel_gb, self.disk_total_gb) if self.disk_total_gb > 0 else sel_gb
+        total_gb = self.disk_total_gb
+        dsk_pct = (sel_gb / total_gb * 100) if total_gb > 0 else 0
+        game_pct = int(len(self.selected_indices) / len(self.games) * 100) if self.games else 0
+
+        if dsk_pct < 50:
+            bar_style = "green.Horizontal.TProgressbar"
+        elif dsk_pct < 80:
+            bar_style = "yellow.Horizontal.TProgressbar"
+        else:
+            bar_style = "red.Horizontal.TProgressbar"
+
+        text = f"{sel_gb:.2f} GB / {total_gb:.2f} GB ({dsk_pct:.1f}%)  |  {game_pct}%"
+        self.progress_text.set(text)
+        self.progress_bar["value"] = dsk_pct
+        self.progress_bar.configure(style=bar_style)
+
+    def run(self):
+        self.root.mainloop()
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan games folder and interactively select which to install."
+    )
+    parser.add_argument(
+        "--games-dir",
+        help="Path to the games folder containing CD/, DVD/, POPS/ subdirectories"
+    )
+    parser.add_argument(
+        "--from-list", action="append", dest="from_lists", default=[],
+        help="Read games from a pipe-delimited list file (can be repeated)"
+    )
+    parser.add_argument(
+        "--output",
+        help="Write selected games (pipe-delimited) to this file"
+    )
+    parser.add_argument(
+        "--disk-total-gb", type=float, default=0.0,
+        help="Total capacity of the target disk in GB (for progress bar)"
+    )
+    args = parser.parse_args()
+
+    if not args.games_dir and not args.from_lists:
+        parser.error("Provide either --games-dir or --from-list (or both).")
+
+    games = []
+
+    if args.from_lists:
+        games.extend(_load_games_from_lists(args.from_lists))
+        print(f"Loaded {len(games)} game(s) from list files.", file=sys.stderr)
+
+    if args.games_dir:
+        script_dir = Path(__file__).resolve().parent
+        titles_ps2 = _load_titles_db(str(script_dir / "TitlesDB_PS2.csv"))
+        titles_ps1 = _load_titles_db(str(script_dir / "TitlesDB_PS1.csv"))
+        scanned = scan_games(args.games_dir, titles_ps2, titles_ps1)
+        seen = {g.game_id for g in games}
+        for g in scanned:
+            if g.game_id not in seen:
+                seen.add(g.game_id)
+                games.append(g)
+
+    if not games:
+        print("No games found.", file=sys.stderr)
+        sys.exit(0)
+
+    if not sys.stdout.isatty() or not sys.stdin.isatty():
+        print("ERROR: Terminal is not fully interactive.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        app = GameSelectorNG(games, args.output, args.disk_total_gb)
+        app.run()
+    except Exception as exc:
+        print(f"ERROR: Game selector failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/helper/game-selector.py
+++ b/scripts/helper/game-selector.py
@@ -1,0 +1,788 @@
+#!/usr/bin/env python3
+#
+# Game Selector for the PSBBN Definitive Project
+# Copyright (C) 2024-2026 CosmicScale
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Interactive game selector with multiselect and progress bar using Textual.
+
+Scans a games directory (containing CD/, DVD/, POPS/ subfolders), extracts
+game IDs and titles, presents an interactive TUI for selection, and writes
+the chosen games to an output file in pipe-delimited format.
+"""
+
+import sys
+import argparse
+import os
+import re
+import math
+import lz4.block
+import unicodedata
+from pathlib import Path
+from struct import unpack
+from collections import defaultdict
+
+from textual.app import App, ComposeResult
+from textual.widgets import SelectionList, ProgressBar, Button, Header, Footer, Static, Input
+from textual.containers import Horizontal, VerticalScroll
+from textual import on
+
+
+# ── ISO / ZSO / VCD helpers (from list-builder.py) ──────────────────────
+
+ZISO_MAGIC = 0x4F53495A
+SECTOR_SIZE = 2048
+_PATTERN_1 = [b'\x01', b'\x0D']
+_PATTERN_2 = [b'\x3B', b'\x31']
+
+
+def _read_zso_header(fin):
+    data = fin.read(24)
+    return unpack('IIQIbbxx', data)
+
+
+def _lz4_decompress(compressed, block_size):
+    while True:
+        try:
+            return lz4.block.decompress(compressed, uncompressed_size=block_size)
+        except lz4.block.LZ4BlockError:
+            compressed = compressed[:-1]
+
+
+def _decompress_zso_sector(fin, index_buf, block_size, align, sector, num_sectors=1):
+    start_byte = sector * SECTOR_SIZE
+    end_byte = (sector + num_sectors) * SECTOR_SIZE
+    decompressed = bytearray()
+    total_blocks = len(index_buf) - 1
+    block_start_num = start_byte // block_size
+    block_end_num = (end_byte + block_size - 1) // block_size
+
+    for block in range(block_start_num, min(block_end_num, total_blocks)):
+        index = index_buf[block]
+        plain = index & 0x80000000
+        index &= 0x7FFFFFFF
+        read_pos = index << align
+        next_index = index_buf[block + 1] & 0x7FFFFFFF
+        read_size = (next_index - index) << align
+        fin.seek(read_pos)
+        data = fin.read(read_size)
+        dec_data = data if plain else _lz4_decompress(data, block_size)
+        block_start = block * block_size
+        block_end = block_start + len(dec_data)
+        lo = max(start_byte - block_start, 0)
+        hi = min(end_byte - block_start, len(dec_data))
+        decompressed.extend(dec_data[lo:hi])
+    return decompressed
+
+
+def _read_iso_sector(fin, sector, num_sectors=1):
+    fin.seek(sector * SECTOR_SIZE)
+    return fin.read(num_sectors * SECTOR_SIZE)
+
+
+def _parse_dir_entries(data):
+    entries = []
+    offset = 0
+    while offset < len(data):
+        length = data[offset]
+        if length == 0:
+            offset = (offset // SECTOR_SIZE + 1) * SECTOR_SIZE
+            continue
+        record = data[offset:offset + length]
+        lba = int.from_bytes(record[2:6], "little")
+        size = int.from_bytes(record[10:14], "little")
+        name = record[33:33 + record[32]].decode("utf-8", errors="ignore")
+        entries.append((name, lba, size))
+        offset += length
+    return entries
+
+
+def _extract_game_id_from_disc(fin, sector_reader):
+    pvd = sector_reader(16, 1)
+    root_record = pvd[156:190]
+    root_lba = int.from_bytes(root_record[2:6], "little")
+    root_size = int.from_bytes(root_record[10:14], "little")
+    nsect = (root_size + SECTOR_SIZE - 1) // SECTOR_SIZE
+    root_data = sector_reader(root_lba, nsect)
+
+    for name, lba, size in _parse_dir_entries(root_data):
+        if name.upper().startswith("SYSTEM.CNF"):
+            nsect = (size + SECTOR_SIZE - 1) // SECTOR_SIZE
+            text = sector_reader(lba, nsect).decode("utf-8", errors="ignore")
+            for line in text.splitlines():
+                if line.strip().upper().startswith("BOOT2"):
+                    return line.split("\\")[-1].split(";")[0].upper()
+    return None
+
+
+def _clean_name_from_filename(name, game_id):
+    base = os.path.splitext(name)[0]
+    if base.upper().startswith(game_id):
+        stripped = base[len(game_id):].lstrip('_. ')
+        return stripped if stripped else base
+    return base
+
+
+def _make_partition_label(game_id, title, suffix):
+    tid = re.sub(r'_(...)\.', r'-\1', game_id).replace('.', '')
+    title = title.replace('²', '2').replace('³', '3')
+    ascii_ = unicodedata.normalize('NFKD', title).encode('ascii', 'ignore').decode()
+    ascii_ = re.sub(r'[^A-Z0-9]', '_', ascii_.upper())
+    ascii_ = re.sub(r'^_+|_+$', '', ascii_)
+    ascii_ = re.sub(r'_+', '_', ascii_)
+    label = f"PP.{tid}.{suffix}.{ascii_}"[:32].rstrip('_')
+    return label
+
+
+# ── Game scanning ───────────────────────────────────────────────────────
+
+def _load_titles_db(csv_path):
+    db = {}
+    if os.path.isfile(csv_path):
+        with open(csv_path) as f:
+            for line in f:
+                parts = line.strip().split('|')
+                if len(parts) == 4:
+                    db[parts[0]] = (parts[1], parts[2], parts[3])
+    return db
+
+
+class GameEntry:
+    __slots__ = ('title', 'game_id', 'publisher', 'disc_type',
+                 'filename', 'jpn_title', 'partition_label', 'file_path')
+
+    def __init__(self, title, game_id, publisher, disc_type,
+                 filename, jpn_title, partition_label, file_path):
+        self.title = title
+        self.game_id = game_id
+        self.publisher = publisher
+        self.disc_type = disc_type
+        self.filename = filename
+        self.jpn_title = jpn_title
+        self.partition_label = partition_label
+        self.file_path = file_path
+
+    @property
+    def display_name(self):
+        parts = [f"[{self.disc_type}]", self.title]
+        if self.game_id:
+            parts.append(f"({self.game_id})")
+        if self.publisher:
+            parts.append(f"· {self.publisher}")
+        if self.file_path:
+            try:
+                size = self.file_path.stat().st_size
+                parts.append(f"· {size / 1_000_000_000:.2f} GB")
+            except OSError:
+                pass
+        return " ".join(parts)
+
+    @property
+    def pipe_line(self):
+        return (f"{self.title}|{self.game_id}|{self.publisher}|"
+                f"{self.disc_type}|{self.filename}|"
+                f"{self.jpn_title}|{self.partition_label}")
+
+    @property
+    def size_gb(self):
+        try:
+            return self.file_path.stat().st_size / 1_000_000_000 if self.file_path else 0.0
+        except OSError:
+            return 0.0
+
+
+def _extract_id_from_image(file_path, image):
+    """Try to extract a Game ID from a single image file. Returns ('', image) on failure."""
+    ext = image.lower()
+    game_id = ""
+
+    # ── from filename if it already looks like a Game ID ──
+    name_no_ext = os.path.splitext(image)[0]
+    if len(name_no_ext) >= 11 and name_no_ext[4] == '_' and name_no_ext[8] == '.':
+        game_id = name_no_ext[:11].upper()
+
+    # ── ISO via SYSTEM.CNF ──
+    if ext.endswith('.iso') and not game_id:
+        try:
+            with open(file_path, "rb") as fin:
+                reader = lambda s, n=1: _read_iso_sector(fin, s, n)
+                game_id = _extract_game_id_from_disc(fin, reader) or ""
+        except Exception:
+            game_id = ""
+
+    # ── ZSO via SYSTEM.CNF ──
+    if ext.endswith('.zso') and not game_id:
+        try:
+            with open(file_path, "rb") as fin:
+                magic, hdr_sz, total, blk_sz, ver, align = _read_zso_header(fin)
+                if magic == ZISO_MAGIC:
+                    nblk = total // blk_sz
+                    idx = [unpack('I', fin.read(4))[0] for _ in range(nblk + 1)]
+                    reader = lambda s, n=1: _decompress_zso_sector(fin, idx, blk_sz, align, s, n)
+                    game_id = _extract_game_id_from_disc(fin, reader) or ""
+        except Exception:
+            game_id = ""
+
+    # ── VCD via cdrom: in header ──
+    if ext.endswith('.vcd') and not game_id:
+        try:
+            with open(file_path, "rb") as f:
+                for raw in f:
+                    line = raw.strip()
+                    low = line.lower()
+                    if b'cdrom:' in low and b'boot' in low:
+                        seg = line[low.find(b'cdrom:') + 6:].split(b';', 1)[0]
+                        g = seg.split(b'\\')[-1].decode('utf-8', errors='ignore').upper()
+                        if len(g) == 11:
+                            if g.startswith("SLUSP"):
+                                g = "SLUS" + g[5:]
+                            if g[4] != '_' or g[8] != '.':
+                                cleaned = g.replace('_', '').replace('.', '').replace('-', '')
+                                g = cleaned[:4] + '_' + cleaned[4:7] + '.' + cleaned[7:]
+                            game_id = g
+                        break
+        except Exception:
+            game_id = ""
+
+    # ── fallback binary scan for ISO / VCD ──
+    if (len(game_id) < 11 or len(game_id) > 12) and (ext.endswith('.iso') or ext.endswith('.vcd')):
+        try:
+            with open(file_path, "rb") as f:
+                data = f.read()
+            idx = 0
+            game_id = ""
+            for byte in data:
+                if len(game_id) < 4:
+                    if idx == 2:
+                        game_id += chr(byte)
+                    elif byte == _PATTERN_1[idx][0]:
+                        idx += 1
+                    else:
+                        game_id = ""
+                        idx = 0
+                elif len(game_id) == 4:
+                    idx = 0
+                    if byte in (0x5F, 0x2D):
+                        game_id += '_'
+                    else:
+                        game_id = ""
+                elif len(game_id) < 8:
+                    game_id += chr(byte)
+                elif len(game_id) == 8:
+                    if byte == 0x2E:
+                        game_id += '.'
+                    else:
+                        game_id = ""
+                elif len(game_id) < 11:
+                    game_id += chr(byte)
+                elif len(game_id) == 11:
+                    if byte == _PATTERN_2[idx][0]:
+                        idx += 1
+                        if idx == 2:
+                            if game_id == "CDDA_END.DA":
+                                game_id = ""
+                                idx = 0
+                                continue
+                            break
+                    else:
+                        game_id = ""
+                        idx = 0
+        except Exception:
+            game_id = ""
+
+    # ── generate from filename as last resort ──
+    if not game_id:
+        base = re.sub(r'[^A-Z0-9]', '', os.path.splitext(image)[0].upper())
+        base = base[:9].ljust(9, '0')
+        game_id = (base[:4] + '_' + base[4:7] + '.' + base[7:])[:11]
+
+    return game_id.upper()
+
+
+def scan_games(games_dir, titles_db_ps2, titles_db_ps1):
+    """Scan CD/, DVD/, POPS/ directories and return a list of GameEntry objects."""
+    base = Path(games_dir)
+    targets = [
+        ("CD",   ['.iso', '.zso'],         "CD",   titles_db_ps2),
+        ("DVD",  ['.iso', '.zso'],         "DVD",  titles_db_ps2),
+        ("POPS", ['.vcd', '.VCD'],         "POPS", titles_db_ps1),
+    ]
+
+    game_id_counts = defaultdict(int)
+    raw = []  # list of dicts, 1st pass
+
+    for folder, exts, disc_type, db in targets:
+        p = base / folder
+        if not p.is_dir():
+            continue
+
+        for image in sorted(os.listdir(str(p))):
+            if image.startswith('.') or not any(image.lower().endswith(e) for e in exts):
+                continue
+
+            file_path = p / image
+            game_id = _extract_id_from_image(str(file_path), image)
+
+            entry = db.get(game_id)
+            if entry:
+                game_name, publisher, jpn_title = entry
+                if not game_name:
+                    game_name = os.path.splitext(image)[0]
+                    publisher = ""
+                    jpn_title = ""
+            else:
+                game_name = _clean_name_from_filename(image, game_id)
+                publisher = ""
+                jpn_title = ""
+
+            game_id_counts[game_id] += 1
+            raw.append(dict(game_id=game_id, game_name=game_name,
+                            publisher=publisher, disc_type=disc_type,
+                            filename=image, jpn_title=jpn_title,
+                            file_path=file_path))
+
+    # 2nd pass: build final GameEntry list with partition labels
+    game_id_index = defaultdict(int)
+    games = []
+    for r in raw:
+        gid = r["game_id"]
+        game_id_index[gid] += 1
+        suffix = f"{game_id_index[gid]:02d}"
+
+        if game_id_counts[gid] > 1:
+            display_name = _clean_name_from_filename(r["filename"], gid)
+        else:
+            display_name = r["game_name"]
+
+        label = _make_partition_label(gid, r["game_name"], suffix)
+
+        games.append(GameEntry(
+            title=display_name,
+            game_id=gid,
+            publisher=r["publisher"],
+            disc_type=r["disc_type"],
+            filename=r["filename"],
+            jpn_title=r["jpn_title"],
+            partition_label=label,
+            file_path=r["file_path"],
+        ))
+
+    return games
+
+
+# ── Textual TUI ─────────────────────────────────────────────────────────
+
+class GameSelector(App[None]):
+    BINDINGS = [
+        ("up", "list_up", ""),
+        ("down", "list_down", ""),
+        ("shift+up", "list_sel_up", ""),
+        ("shift+down", "list_sel_down", ""),
+        ("space", "list_toggle", ""),
+        ("ctrl+a", "select_all", "All"),
+        ("ctrl+shift+a", "deselect_all", "Clear"),
+        ("ctrl+enter", "confirm", "Confirm"),
+        ("escape", "cancel", "Cancel"),
+    ]
+
+    CSS = """
+    Screen {
+        background: #0f1117;
+        padding: 0 1;
+    }
+    Header {
+        background: #161820;
+        color: #868d9e;
+        text-style: bold;
+    }
+    Footer {
+        background: #161820;
+        color: #868d9e;
+    }
+    #toolbar {
+        height: 3;
+        background: #1a1c25;
+        padding: 0 1;
+    }
+    #search {
+        width: 1fr;
+        height: 3;
+        background: #1e2030;
+        border: tall #2a2d3e;
+        color: #e2e4eb;
+    }
+    #search:focus {
+        background: #282a36;
+        border: tall #50fa7b;
+    }
+    Button {
+        background: #1e2030;
+        border: none;
+        text-style: bold;
+    }
+    Button:hover {
+        background: #282a36;
+    }
+    #toolbar Button, #buttons Button {
+        height: 3;
+    }
+    #select_all, #deselect_all {
+        width: 12;
+        margin: 0 0 0 1;
+    }
+    #select_all {
+        color: #50fa7b;
+    }
+    #deselect_all {
+        color: #ff5555;
+    }
+    #type_info {
+        height: 1;
+        text-align: center;
+        color: #c0c4d0;
+        text-style: bold;
+    }
+    #list_container {
+        height: 1fr;
+    }
+    #game_list {
+        height: auto;
+        background: #161820;
+        border: none;
+        text-style: bold;
+    }
+    #bar_info {
+        height: 1;
+        text-align: center;
+        color: #c0c4d0;
+        text-style: bold;
+    }
+    #buttons {
+        height: 3;
+    }
+    #confirm, #cancel {
+        width: 1fr;
+    }
+    #confirm {
+        color: #50fa7b;
+    }
+    #cancel {
+        color: #ff5555;
+    }
+    """
+
+    def __init__(self, games, output_file=None, disk_total_gb=0.0):
+        super().__init__()
+        self.games = games
+        self.output_file = output_file
+        self.disk_total_gb = disk_total_gb or 0.0
+        self.selected_indices: set[int] = set()
+        self._focus_idx = 0
+        self._dt_width = 5  # [PS2] or [PS1]
+        self._id_width = max(len(g.game_id) for g in games) if games else 11
+        self._visible_ps2 = len(games)
+        self._visible_ps1 = 0
+
+    def compose(self):
+        yield Header()
+        with Horizontal(id="toolbar"):
+            yield Input(placeholder="Filter by name or ID...", id="search")
+            yield Button("All", id="select_all", variant="primary")
+            yield Button("Clear", id="deselect_all")
+        yield Static("", id="type_info")
+        with VerticalScroll(id="list_container"):
+            yield SelectionList[int](id="game_list")
+        yield Static("", id="bar_info")
+        with Horizontal(id="buttons"):
+            yield Button("Confirm", id="confirm", variant="primary")
+            yield Button("Cancel", id="cancel")
+        yield Footer()
+
+    def on_mount(self):
+        self._rebuild_lists()
+        self._update_progress()
+
+    @staticmethod
+    def _fmt_game_line(g, dt_width, id_width):
+        prefix = "PS1" if g.disc_type == "POPS" else "PS2"
+        dt = f"[{prefix}]".ljust(dt_width)
+        sz = f"{g.size_gb:>6.2f} GB"
+        id_ = f"({g.game_id})".ljust(id_width + 2)
+        return f"[bold]{dt} \u2502 {sz} \u2502 {id_} \u2502 {g.title}[/]"
+
+    def _list_focused(self) -> bool:
+        lst = self.query_one("#game_list", SelectionList)
+        if lst.has_focus:
+            return True
+        for child in lst.children:
+            if child.has_focus:
+                return True
+        return False
+
+    def _scroll_to_focus(self):
+        self.query_one("#list_container", VerticalScroll).scroll_to(
+            y=self._focus_idx, animate=False
+        )
+
+    def action_list_up(self):
+        if self._focus_idx > 0:
+            self._focus_idx -= 1
+            self._scroll_to_focus()
+
+    def action_list_down(self):
+        if self._focus_idx < len(self.games) - 1:
+            self._focus_idx += 1
+            self._scroll_to_focus()
+
+    def action_list_sel_up(self):
+        if not self._list_focused() or self._focus_idx < 1:
+            return
+        self.selected_indices.add(self._focus_idx - 1)
+        self._focus_idx -= 1
+        self._rebuild_lists(self.query_one("#search", Input).value)
+        self._refresh_ui()
+        self._scroll_to_focus()
+
+    def action_list_sel_down(self):
+        if not self._list_focused() or self._focus_idx >= len(self.games) - 1:
+            return
+        self.selected_indices.add(self._focus_idx + 1)
+        self._focus_idx += 1
+        self._rebuild_lists(self.query_one("#search", Input).value)
+        self._refresh_ui()
+        self._scroll_to_focus()
+
+    def action_list_toggle(self):
+        if not self._list_focused():
+            return
+        if self._focus_idx in self.selected_indices:
+            self.selected_indices.discard(self._focus_idx)
+        else:
+            self.selected_indices.add(self._focus_idx)
+        self._rebuild_lists(self.query_one("#search", Input).value)
+        self._refresh_ui()
+        self._scroll_to_focus()
+
+    def action_select_all(self):
+        self.selected_indices = set(range(len(self.games)))
+        self._rebuild_lists(self.query_one("#search", Input).value)
+        self._refresh_ui()
+
+    def action_deselect_all(self):
+        self.selected_indices.clear()
+        self._rebuild_lists(self.query_one("#search", Input).value)
+        self._refresh_ui()
+
+    def action_confirm(self):
+        chosen = [self.games[i] for i in self.selected_indices]
+        if self.output_file:
+            with open(self.output_file, "w") as f:
+                for g in chosen:
+                    f.write(g.pipe_line + "\n")
+        else:
+            for g in chosen:
+                print(g.pipe_line)
+        self.exit()
+
+    def action_cancel(self):
+        sys.exit(2)
+
+    def _rebuild_lists(self, query: str = ""):
+        q = query.strip().lower()
+        saved = set(self.selected_indices)
+        lst = self.query_one("#game_list", SelectionList)
+
+        self._visible_ps2 = sum(
+            1 for i, g in enumerate(self.games) if g.disc_type in ("CD", "DVD")
+            and (not q or q in g.title.lower() or q in g.game_id.lower())
+        )
+        self._visible_ps1 = sum(
+            1 for i, g in enumerate(self.games) if g.disc_type == "POPS"
+            and (not q or q in g.title.lower() or q in g.game_id.lower())
+        )
+
+        self._update_type_info()
+
+        with self.prevent(SelectionList.SelectedChanged):
+            lst.clear_options()
+
+            for dt in ("CD", "DVD", "POPS"):
+                type_games = [(i, g) for i, g in enumerate(self.games) if g.disc_type == dt]
+
+                filtered = [(i, g) for i, g in type_games
+                            if not q or q in g.title.lower() or q in g.game_id.lower()]
+
+                for idx, g in filtered:
+                    label = self._fmt_game_line(g, self._dt_width, self._id_width)
+                    lst.add_option((label, idx, idx in saved))
+
+    @on(Input.Changed, "#search")
+    def on_search(self, event: Input.Changed):
+        self._rebuild_lists(event.value)
+        self._refresh_ui()
+
+    @on(SelectionList.SelectedChanged)
+    def on_selection_changed(self):
+        self.selected_indices.clear()
+        lst = self.query_one("#game_list", SelectionList)
+        self.selected_indices.update(i for i in lst.selected if i >= 0)
+        if self.selected_indices:
+            self._focus_idx = min(self.selected_indices)
+        self._refresh_ui()
+
+    def _refresh_ui(self):
+        self._update_type_info()
+        self._update_progress()
+
+    def _update_type_info(self):
+        sel = len(self.selected_indices)
+        total = len(self.games)
+        gb = sum(self.games[i].size_gb for i in self.selected_indices)
+        self.query_one("#type_info", Static).update(
+            f"[#8be9fd]PS2 ({self._visible_ps2})[/]  │  "
+            f"[#ffb86c]PS1 ({self._visible_ps1})[/]"
+            f"  │  {sel} / {total} games selected  ·  {gb:.2f} GB"
+        )
+
+    def _update_progress(self):
+        sel_gb = sum(self.games[i].size_gb for i in self.selected_indices)
+        sel_gb = min(sel_gb, self.disk_total_gb) if self.disk_total_gb > 0 else sel_gb
+        total_gb = self.disk_total_gb
+        dsk_pct = (sel_gb / total_gb * 100) if total_gb > 0 else 0
+        game_pct = int(len(self.selected_indices) / len(self.games) * 100) if self.games else 0
+
+        prefix = f"{sel_gb:.2f} GB / {total_gb:.2f} GB ({dsk_pct:.1f}%)  |  {game_pct}% "
+        bar_w = max(10, self.size.width - len(prefix) - 5) if hasattr(self, 'size') else 20
+        filled = min(int(dsk_pct / 100 * bar_w), bar_w)
+        bar = "\u2588" * filled + "\u2591" * (bar_w - filled)
+
+        if dsk_pct < 50:
+            color = "#50fa7b"
+        elif dsk_pct < 80:
+            color = "#ffb86c"
+        else:
+            color = "#ff5555"
+
+        self.query_one("#bar_info", Static).update(
+            f"{prefix}[{color}]{bar}[/]"
+        )
+
+    @on(Button.Pressed, "#select_all")
+    def on_select_all(self):
+        self.selected_indices = {i for i, _ in enumerate(self.games)}
+        self._rebuild_lists(self.query_one("#search", Input).value)
+        self._refresh_ui()
+
+    @on(Button.Pressed, "#deselect_all")
+    def on_deselect_all(self):
+        self.selected_indices.clear()
+        self._rebuild_lists(self.query_one("#search", Input).value)
+        self._refresh_ui()
+
+    @on(Button.Pressed, "#confirm")
+    def on_confirm(self):
+        chosen = [self.games[i] for i in self.selected_indices]
+        if self.output_file:
+            with open(self.output_file, "w") as f:
+                for g in chosen:
+                    f.write(g.pipe_line + "\n")
+        else:
+            for g in chosen:
+                print(g.pipe_line)
+        self.exit()
+
+    @on(Button.Pressed, "#cancel")
+    def on_cancel(self):
+        sys.exit(2)
+
+    @on(Button.Pressed, "#cancel")
+    def on_cancel(self):
+        sys.exit(2)
+
+
+# ── Entry point ─────────────────────────────────────────────────────────
+
+def _load_games_from_lists(list_files):
+    """Load GameEntry objects from pipe-delimited list files (PS1_LIST / PS2_LIST format)."""
+    games = []
+    for lf in list_files:
+        try:
+            with open(lf) as f:
+                for line in f:
+                    parts = line.strip().split("|")
+                    if len(parts) >= 7:
+                        title, game_id, publisher, disc_type, filename, jpn_title, label = parts[:7]
+                        games.append(GameEntry(
+                            title=title, game_id=game_id, publisher=publisher,
+                            disc_type=disc_type, filename=filename,
+                            jpn_title=jpn_title, partition_label=label,
+                            file_path=None,
+                        ))
+        except OSError:
+            pass
+    return games
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan games folder and interactively select which to install."
+    )
+    parser.add_argument(
+        "--games-dir",
+        help="Path to the games folder containing CD/, DVD/, POPS/ subdirectories"
+    )
+    parser.add_argument(
+        "--from-list", action="append", dest="from_lists", default=[],
+        help="Read games from a pipe-delimited list file (can be repeated)"
+    )
+    parser.add_argument(
+        "--output",
+        help="Write selected games (pipe-delimited) to this file"
+    )
+    parser.add_argument(
+        "--disk-total-gb", type=float, default=0.0,
+        help="Total capacity of the target disk in GB (for progress bar)"
+    )
+    args = parser.parse_args()
+
+    if not args.games_dir and not args.from_lists:
+        parser.error("Provide either --games-dir or --from-list (or both).")
+
+    games = []
+
+    if args.from_lists:
+        games.extend(_load_games_from_lists(args.from_lists))
+        print(f"Loaded {len(games)} game(s) from list files.", file=sys.stderr)
+
+    if args.games_dir:
+        script_dir = Path(__file__).resolve().parent
+        titles_ps2 = _load_titles_db(str(script_dir / "TitlesDB_PS2.csv"))
+        titles_ps1 = _load_titles_db(str(script_dir / "TitlesDB_PS1.csv"))
+        scanned = scan_games(args.games_dir, titles_ps2, titles_ps1)
+        # Union with dedup by game_id (will only trigger if both --from-list and --games-dir given)
+        seen = {g.game_id for g in games}
+        for g in scanned:
+            if g.game_id not in seen:
+                seen.add(g.game_id)
+                games.append(g)
+
+    if not games:
+        print("No games found.", file=sys.stderr)
+        sys.exit(0)
+
+    if not sys.stdout.isatty() or not sys.stdin.isatty():
+        print("ERROR: Terminal is not fully interactive (stdout TTY:", sys.stdout.isatty(), "stdin TTY:", sys.stdin.isatty(), ")", file=sys.stderr)
+        print("ERROR: Terminal is not fully interactive. Cannot open the game selector.", file=sys.stdout)
+        sys.exit(1)
+
+    try:
+        app = GameSelector(games, args.output, args.disk_total_gb)
+        app.run()
+    except Exception as exc:
+        print(f"ERROR: Game selector failed: {exc}", file=sys.stderr)
+        print(f"ERROR: Game selector failed: {exc}", file=sys.stdout)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

I added two scripts—one based on Textual and the other on GTK—because I was unsure which one to actually keep in the project; it is currently running with Textual, but both do exactly the same thing.

# Features

- Add dynamic progress bar to interactive game selector showing selected games size vs disk capacity
- Implement danger-aligned color coding: 🟢 Green (<25%), 🔵 Blue (25-50%), 🟡 Yellow (50-60%), 🔴 Red (≥60%)
- Search bar to filter games by name
- Select All and Clear buttons
- MultSelect with keyboard
- Show quantity by folder PS2 (XX) PS1 (YY) and update by search filter

## Test Plan

1. Run `konsole -e "python3 scripts/helper/game-selector.py /tmp/ps1.list /tmp/ps2.list --disk-total-gb 500 --games-dir games --output /tmp/selected.list"`
2. Verify ProgressBar updates on selection toggle
3. Confirm color changes at 25%, 50%, 60% thresholds
4. Check label shows correct GB values and percentage

# Env

Tested on:

PRETTY_NAME="Ubuntu 26.04 LTS"
NAME="Ubuntu"
VERSION_ID="26.04"
VERSION="26.04 LTS (Resolute Raccoon)"
VERSION_CODENAME=resolute
ID=ubuntu
ID_LIKE=debian
UBUNTU_CODENAME=resolute
LOGO=ubuntu-logo
