### PR TITLE
Add Gentoo Support; migrate from zip+unzip+unrar-free to bsdtar

### DIFF
--- a/PSBBN-Definitive-Patch.sh
+++ b/PSBBN-Definitive-Patch.sh
@@ -526,8 +526,6 @@ check_dep(){
     check_cmd bc
     check_cmd rsync
     check_cmd curl
-    check_cmd zip
-    check_cmd unzip
     check_cmd wget
     check_cmd ffmpeg
     check_cmd lvm

--- a/PSBBN-Definitive-Patch.sh
+++ b/PSBBN-Definitive-Patch.sh
@@ -540,7 +540,7 @@ check_dep(){
     check_cmd bchunk
     check_cmd pkg-config
     check_cmd ffmpegthumbnailer
-    check_cmd unrar-free
+    check_cmd bsdtar
     check_cmd dmsetup
 
     if ! pkg-config --exists icu-i18n 2>/dev/null; then

--- a/README.md
+++ b/README.md
@@ -1153,7 +1153,7 @@ The full readme can be found [here](https://github.com/pcm720/OSDMenu/blob/main/
 **Warning: Manually creating new APA partitions on your PS2 drive and exceeding the allocated space for APA will corrupt the drive.**
 
 ## Early (SCPH-10000–18000) and Slim (SCPH-700xx) Consoles
-The **PSBBN Definitive Project** can be installed on PS2 Slim **SCPH-700xx** models with an [IDE Resurrector](https://gusse.in/shop/ps2-modding-parts/ide-resurrector-origami-v0-7-flex-cable-for-ps2-slim-spch700xx/) or similar hardware mod. Installing to an SD card is not supported on Windows. For PSBBN compatibility, an SATA adapter must be used, such as the [iFlash-Sata v10](https://www.iflash.xyz/store/iflash-sata-v10/).
+The **PSBBN Definitive Project** can be installed on PS2 Slim **SCPH-700xx** models with an [IDE Resurrector](https://gusse.in/shop/ps2-modding-parts/ide-resurrector-origami-v0-7-flex-cable-for-ps2-slim-spch700xx/) or similar hardware mod. Installing to an SD card is not supported on Windows. For PSBBN compatibility, a SATA adapter must be used, such as the [iFlash-Sata v10](https://www.iflash.xyz/store/iflash-sata-v10/).
 
 You must also download the [External HDD Drivers](https://israpps.github.io/FreeMcBoot-Installer/test/8_Downloads.html). Extract the files and place `hddload.irx`, `dev9.irx`, and `atad.irx` in the appropriate system folder for your region on an **official Sony PS2 Memory Card**:
 

--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ For the best experience, a PS2 Fat model (SCPH-30000 to SCPH-55000 series) is re
 The **PSBBN Definitive Project** requires an x86-64 or ARM64 PC for installation. Connect the HDD or SSD to the PC via SATA or a USB adapter.
 
 ## Installing on Linux
-64-bit Debian-based distributions using `apt`, Arch-based distributions using `pacman`, and Fedora-based[*](#troubleshooting) distributions using `dnf` are supported. Nix-based systems are also supported via flakes. Recommended distributions are Linux Mint, Debian, and for Raspberry Pi, Raspberry Pi OS.
+64-bit Debian-based distributions using `apt`, Arch-based distributions using `pacman`, Fedora-based[*](#troubleshooting) distributions using `dnf`, and Gentoo-based distributions using `emerge` are supported. Nix-based systems are also supported via flakes. Recommended distributions are Linux Mint, Debian, and for Raspberry Pi, Raspberry Pi OS.
 
 **The PSBBN Definitive Project is a rolling release. To get automatic updates and the latest bug fixes, you must install the scripts using `git clone`.**
 

--- a/scripts/Game-Installer.sh
+++ b/scripts/Game-Installer.sh
@@ -473,7 +473,7 @@ POPS_PATCH_DL() {
         wget -qO- 'https://www.mediafire.com/file/rznkr05pci45w5p/Hugopocked_POPStarter_Fixes_%25282023-08-11%2529.rar/file' \
         | grep -o 'https://download[^"]*Hugopocked+POPStarter+Fixes+%282023-08-11%29.rar' | head -n1)"
 
-    unrar-free x "${ASSETS_DIR}/Hugopocked_POPStarter_Fixes.rar" "$ASSETS_DIR"
+    bsdtar -xf "${ASSETS_DIR}/Hugopocked_POPStarter_Fixes.rar" -C "$ASSETS_DIR"
 }
 
 CREATE_PS1_VMC() {

--- a/scripts/Game-Installer.sh
+++ b/scripts/Game-Installer.sh
@@ -920,7 +920,7 @@ install_pops() {
             if [[ -f "${ASSETS_DIR}/POPS-binaries-main.zip" && ! -f "${ASSETS_DIR}/POPS-binaries-main.zip.st" ]]; then
                 echo | tee -a "${LOG_FILE}"
                 echo "POPS-binaries-main.zip found in ${ASSETS_DIR}. Extracting..." >> "${LOG_FILE}"
-                if ! unzip -o "${ASSETS_DIR}/POPS-binaries-main.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1; then
+                if ! bsdtar -xf "${ASSETS_DIR}/POPS-binaries-main.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1; then
                     echo "[!] Warning: Failed to extract POPS binaries." >> "${LOG_FILE}"
                     error_msg "Warning" "${UI_TEXT[WARN_INSTALL_POPS_1]}"
                 fi
@@ -932,7 +932,7 @@ install_pops() {
                     echo "[!] Warning: Failed to download POPS binaries." >> "${LOG_FILE}"
                     error_msg "Warning" "Failed to download POPS binaries."
                 fi
-                if ! unzip -o "${ASSETS_DIR}/POPS-binaries-main.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1; then
+                if ! bsdtar -xf "${ASSETS_DIR}/POPS-binaries-main.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1; then
                     error_msg "Warning" "${UI_TEXT[WARN_INSTALL_POPS_2]}"
                 fi
             fi
@@ -3943,9 +3943,9 @@ cp "${MISSING_ICON}" "${ICONS_DIR}/ico/tmp" >> "${LOG_FILE}" 2>&1
 
 cd "${ICONS_DIR}/ico/tmp/"
 rm *.png >/dev/null 2>&1
-zip -r "${ARTWORK_DIR}/tmp/ico.zip" * >/dev/null 2>&1
+bsdtar -acf "${ARTWORK_DIR}/tmp/ico.zip" * >/dev/null 2>&1
 cd "${ARTWORK_DIR}/tmp/" 
-zip -r "${ARTWORK_DIR}/tmp/art.zip" * >/dev/null 2>&1
+bsdtar -acf "${ARTWORK_DIR}/tmp/art.zip" * >/dev/null 2>&1
 
 if [ -f "${ARTWORK_DIR}/tmp/art.zip" ]; then
     echo "Contributing to the PSBBN art & HDD-OSD databases..." >> "${LOG_FILE}"

--- a/scripts/HOSDMenu-Installer.sh
+++ b/scripts/HOSDMenu-Installer.sh
@@ -367,14 +367,14 @@ download_files() {
         # Check if extras.zip exists
         if [[ -f "${ASSETS_DIR}/extras.zip" && ! -f "${ASSETS_DIR}/extras.zip.st" ]]; then
             echo "extras.zip found in ${ASSETS_DIR}. Extracting..." >> "${LOG_FILE}"
-            unzip -o "${ASSETS_DIR}/extras.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
+            bsdtar -xf "${ASSETS_DIR}/extras.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
         else
             echo "Downloading..." >> "${LOG_FILE}"
             echo -n "${UI_TEXT[DOWNLOAD_LATEST_FILE_2]}..."
             wget --quiet --timeout=10 --tries=3 -O "${ASSETS_DIR}/extras.zip" https://archive.org/download/psbbn-definitive-english-patch-v2/extras.zip
             echo
             if [[ -s "${ASSETS_DIR}/extras.zip" ]]; then
-                unzip -o "${ASSETS_DIR}/extras.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
+                bsdtar -xf "${ASSETS_DIR}/extras.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
             else
                 rm "${ASSETS_DIR}/extras.zip"
                 echo "[X] Error: Download failed for HDD-OSD." >> "${LOG_FILE}" 2>&1

--- a/scripts/Media-Installer.sh
+++ b/scripts/Media-Installer.sh
@@ -583,14 +583,14 @@ download_ps2str() {
     if [[ -f "${ASSETS_DIR}/ps2str_v1.08_2001.zip" ]]; then
       echo "Found ${ASSETS_DIR}/ps2str_v1.08_2001.zip..." >> "${LOG_FILE}"
         echo "${UI_TEXT[GET_LATEST_FILE_1]} ${ASSETS_DIR}/ps2str_v1.08_2001.zip..."
-        unzip -o "${ASSETS_DIR}/ps2str_v1.08_2001.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
+        bsdtar -xf "${ASSETS_DIR}/ps2str_v1.08_2001.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
     else
         echo "Downloading ps2str..." >> "${LOG_FILE}"
         echo "${UI_TEXT[DOWNLOAD_REQUIRED]}"
         wget --quiet --timeout=10 --tries=3 -O "${ASSETS_DIR}/ps2str_v1.08_2001.zip" https://archive.org/download/ps2str_v1.08_2001/ps2str_v1.08_2001.zip
         echo
         if [[ -s "${ASSETS_DIR}/ps2str_v1.08_2001.zip" ]]; then
-            unzip -o "${ASSETS_DIR}/ps2str_v1.08_2001.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
+            bsdtar -xf "${ASSETS_DIR}/ps2str_v1.08_2001.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
         fi
     fi
 }

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -144,14 +144,14 @@ elif [ -x "$(command -v emerge)" ]; then
     fi
     # Check if device-mapper is in the user's kernel
     # First, see if it's built in
-    if grep -q "device-mapper" /proc/devices 2>/dev/null && ! lsmod 2>/dev/null | grep -q "^dm_mod"; then
+    if grep -q "device-mapper" /proc/devices 2>/dev/null && ! lsmod 2>/dev/null | grep -q "^dm_mod"; then :
     # If it's not built in, see if it's configured as a module
     elif modprobe -n dm_mod &>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then
         # If it's a module, check if it's loaded
-        if grep -q "device-mapper" /proc/devices 2>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then
+        if grep -q "device-mapper" /proc/devices 2>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then :
         else
         # If it's not loaded, attempt to load it
-        if sudo modprobe dm_mod 2>/dev/null; then
+        if sudo modprobe dm_mod 2>/dev/null; then :
         else
         echo "Error: Failed to load the 'dm_mod' kernel module." >&2
         exit 1

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -143,13 +143,10 @@ elif [ -x "$(command -v emerge)" ]; then
         i386="glibc"
     fi
     # Check if device-mapper is in the user's kernel
-    # First, see if it's built in
+    # First, see if it's built into the kernel or if it's a module and currently loaded
     if grep -q "device-mapper" /proc/devices 2>/dev/null && ! lsmod 2>/dev/null | grep -q "^dm_mod"; then :
-    # If it's not built in, see if it's configured as a module
-    elif modprobe -n dm_mod &>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then
-        # If it's a module, check if it's loaded
-        if grep -q "device-mapper" /proc/devices 2>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then :
-        else
+    # If it's not built in or loaded, check if it's built as a module but not currently loaded
+    elif modprobe -n dm_mod &>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then   
         # If it's not loaded, attempt to load it
         if sudo modprobe dm_mod 2>/dev/null; then :
         else
@@ -189,7 +186,7 @@ EOF
             esac
         done
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge --noreplace --quiet --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge --update --quiet --quiet-fail --changed-use --ask net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -171,11 +171,25 @@ media-video/ffmpeg opus
 EOF
 # Swap deprecated exfat-utils with exfatprogs if present
     if portageq has_version / sys-fs/exfat-utils &>/dev/null; then
-        echo "Removing deprecated sys-fs/exfat-utils to prevent package blocks..."
-        sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
-        sudo emerge --unmerge --quiet sys-fs/exfat-utils
+        while true; do
+        read -p "You have deprecated exfat-utils installed. It must be removed for this program to function. Do you want to remove it now and replace it with exfatprogs? (y/n): " yn
+        case $yn in
+            [Yy]* )
+                sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
+                sudo emerge --unmerge --quiet sys-fs/exfat-utils
+                break
+                ;;
+            [Nn]* )
+                echo "Please remove sys-fs/exfat-utils manually before running this script again."
+                exit 0
+                ;;
+            * )
+                echo "Invalid input! Please enter y or n."
+                ;;
+            esac
+        done
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge --noreplace --quiet --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge --noreplace --quiet --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -163,7 +163,19 @@ elif [ -x "$(command -v emerge)" ]; then
     echo "Please rebuild your kernel with CONFIG_BLK_DEV_DM=y or CONFIG_BLK_DEV_DM=m before running this installer." >&2
         exit 1
     fi
-    sudo USE='lvm' emerge --ask net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo mkdir -p /etc/portage/package.use
+    cat << 'EOF' | sudo tee /etc/portage/package.use/psbbn-installer > /dev/null
+    # Specific USE requirements for PSBBN installer dependencies
+sys-fs/lvm2 lvm
+media-video/ffmpeg opus
+EOF
+# Swap deprecated exfat-utils with exfatprogs if present
+    if portageq has_version / sys-fs/exfat-utils &>/dev/null; then
+        echo "Removing deprecated sys-fs/exfat-utils to prevent package blocks..."
+        sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
+        sudo emerge --unmerge --quiet sys-fs/exfat-utils
+    fi
+    sudo emerge --sync && sudo USE='lvm' emerge -q --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -175,7 +175,7 @@ EOF
         sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
         sudo emerge --unmerge --quiet sys-fs/exfat-utils
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge -q --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge -q --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -130,7 +130,7 @@ elif [ -x "$(command -v dnf)" ]; then
         i386="glibc.i686"
     fi
     sudo dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm 2>&1 | tee -a "${LOG_FILE}"
-    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer bsdtar device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer libarchive bsdtar device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Arch-based system, do this instead
 elif [ -x "$(command -v pacman)" ]; then
     if [[ "$arch" = "x86_64" ]]; then

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -175,7 +175,7 @@ EOF
         sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
         sudo emerge --unmerge --quiet sys-fs/exfat-utils
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge -q --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge -qn --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -123,20 +123,47 @@ if [ -x "$(command -v apt-get)" ]; then
         sudo dpkg --add-architecture i386
         i386="libc6:i386"
     fi
-    sudo apt-get -q update && sudo apt-get install -y axel imagemagick xxd python3 python3-venv python3-pip bc rsync curl zip unzip wget ffmpeg lvm2 libfuse2 dosfstools e2fsprogs libc-bin exfatprogs exfat-fuse util-linux fdisk parted bchunk build-essential libicu-dev pkg-config ffmpegthumbnailer binfmt-support unrar-free dmsetup $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo apt-get -q update && sudo apt-get install -y axel imagemagick xxd python3 python3-venv python3-pip bc rsync curl wget ffmpeg lvm2 libfuse2 dosfstools e2fsprogs libc-bin exfatprogs exfat-fuse util-linux fdisk parted bchunk build-essential libicu-dev pkg-config ffmpegthumbnailer binfmt-support libarchive-tools dmsetup $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Fedora-based system, do this instead
 elif [ -x "$(command -v dnf)" ]; then
     if [[ "$arch" = "x86_64" ]]; then
         i386="glibc.i686"
     fi
     sudo dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm 2>&1 | tee -a "${LOG_FILE}"
-    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl zip unzip wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer unrar-free device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer bsdtar device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Arch-based system, do this instead
 elif [ -x "$(command -v pacman)" ]; then
     if [[ "$arch" = "x86_64" ]]; then
         i386="lib32-glibc"
     fi
-    sudo pacman -S --needed --noconfirm axel imagemagick xxd python pyenv python-pip bc rsync curl zip unzip wget ffmpeg lvm2 fuse2 dosfstools e2fsprogs glibc exfatprogs util-linux parted bchunk base-devel icu pkgconf ffmpegthumbnailer unrar-free device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo pacman -S --needed --noconfirm axel imagemagick xxd python pyenv python-pip bc rsync curl wget ffmpeg lvm2 fuse2 dosfstools e2fsprogs glibc exfatprogs util-linux parted bchunk base-devel icu pkgconf ffmpegthumbnailer libarchive device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
+# Or if user is on Gentoo-based system, do this instead
+elif [ -x "$(command -v emerge)" ]; then
+    if [[ "$arch" = "x86_64" ]]; then
+        i386="glibc"
+    fi
+    # Check if device-mapper is in the user's kernel
+    # First, see if it's built in
+    if grep -q "device-mapper" /proc/devices 2>/dev/null && ! lsmod 2>/dev/null | grep -q "^dm_mod"; then
+    # If it's not built in, see if it's configured as a module
+    elif modprobe -n dm_mod &>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then
+        # If it's a module, check if it's loaded
+        if grep -q "device-mapper" /proc/devices 2>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then
+        else
+        # If it's not loaded, attempt to load it
+        if sudo modprobe dm_mod 2>/dev/null; then
+        else
+        echo "Error: Failed to load the 'dm_mod' kernel module." >&2
+        exit 1
+        fi
+    fi
+    else
+    # If it's not present at all, halt and throw this error message
+    echo "Error: device-mapper (CONFIG_BLK_DEV_DM) is missing from your kernel." >&2
+    echo "Please rebuild your kernel with CONFIG_BLK_DEV_DM=y or CONFIG_BLK_DEV_DM=m before running this installer." >&2
+        exit 1
+    fi
+    sudo USE='lvm' emerge --ask net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -175,7 +175,7 @@ EOF
         sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
         sudo emerge --unmerge --quiet sys-fs/exfat-utils
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge -qn --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge --noreplace --quiet --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -40,8 +40,6 @@
           bc
           rsync
           curl
-          zip
-          unzip
           wget
           exfatprogs
           ffmpeg
@@ -50,7 +48,7 @@
           bchunk
           e2fsprogs
           ffmpegthumbnailer
-          unrar-free
+          libarchive
           lvm2
           dosfstools
           util-linux


### PR DESCRIPTION
I switched out checks for `zip`, `unzip`, and `unrar-free` in the main script to only a bsdtar check

I switched the package lists for all distros to pull `libarchive` (contains `bsdtar`) instead of those three packages (including nix)

I added a Gentoo section that checks for `device-mapper` support in-kernel, and installs the required packages

I changed all calls for `zip`, `unzip`, and `unrar-free` in all scripts in the repo to the drop-in `bsdtar` equivalent. 

I tested the new script on both Debian, and the Gentoo LiveCD.

I don't believe this requires extensive testing on all distros, as I have verified the package lists, and parity of functionality between the previous calls for `zip`, `unzip`, and `unrar-free` with new `bsdtar` commands. The Gentoo support does not affect other distros as the script never gets that far.

I also updated README.md to mention Gentoo support.