### PR TITLE
Remove wget dependency

### DIFF
--- a/PSBBN-Definitive-Patch.sh
+++ b/PSBBN-Definitive-Patch.sh
@@ -526,8 +526,6 @@ check_dep(){
     check_cmd bc
     check_cmd rsync
     check_cmd curl
-    check_cmd zip
-    check_cmd unzip
     check_cmd wget
     check_cmd ffmpeg
     check_cmd lvm

--- a/PSBBN-Definitive-Patch.sh
+++ b/PSBBN-Definitive-Patch.sh
@@ -540,7 +540,7 @@ check_dep(){
     check_cmd bchunk
     check_cmd pkg-config
     check_cmd ffmpegthumbnailer
-    check_cmd unrar-free
+    check_cmd bsdtar
     check_cmd dmsetup
 
     if ! pkg-config --exists icu-i18n 2>/dev/null; then

--- a/PSBBN-Definitive-Patch.sh
+++ b/PSBBN-Definitive-Patch.sh
@@ -913,7 +913,7 @@ else
     if [[ -n "$psbbn_version" || -n $osdmenu_version || -n "$LANG_VER" || -n "$CHAN_VER" ]]; then
 
         HTML_FILE=$(mktemp)
-        timeout 20 curl -sSL -o "$HTML_FILE" "$URL" >> "$LOG_FILE" 2>&1
+        curl -sSL -m 20 -o "$HTML_FILE" "$URL" >> "$LOG_FILE" 2>&1
 
         if [[ -n "$psbbn_version" ]]; then
             get_latest_file "psbbn-definitive-patch" "PSBBN Definitive Patch"

--- a/PSBBN-Definitive-Patch.sh
+++ b/PSBBN-Definitive-Patch.sh
@@ -526,7 +526,6 @@ check_dep(){
     check_cmd bc
     check_cmd rsync
     check_cmd curl
-    check_cmd wget
     check_cmd ffmpeg
     check_cmd lvm
     check_cmd timeout
@@ -914,7 +913,7 @@ else
     if [[ -n "$psbbn_version" || -n $osdmenu_version || -n "$LANG_VER" || -n "$CHAN_VER" ]]; then
 
         HTML_FILE=$(mktemp)
-        timeout 20 wget -O "$HTML_FILE" "$URL" -o - >> "$LOG_FILE" 2>&1
+        timeout 20 curl -sSL -o "$HTML_FILE" "$URL" >> "$LOG_FILE" 2>&1
 
         if [[ -n "$psbbn_version" ]]; then
             get_latest_file "psbbn-definitive-patch" "PSBBN Definitive Patch"

--- a/README.md
+++ b/README.md
@@ -1153,7 +1153,7 @@ The full readme can be found [here](https://github.com/pcm720/OSDMenu/blob/main/
 **Warning: Manually creating new APA partitions on your PS2 drive and exceeding the allocated space for APA will corrupt the drive.**
 
 ## Early (SCPH-10000–18000) and Slim (SCPH-700xx) Consoles
-The **PSBBN Definitive Project** can be installed on PS2 Slim **SCPH-700xx** models with an [IDE Resurrector](https://gusse.in/shop/ps2-modding-parts/ide-resurrector-origami-v0-7-flex-cable-for-ps2-slim-spch700xx/) or similar hardware mod. Installing to an SD card is not supported on Windows. For PSBBN compatibility, an SATA adapter must be used, such as the [iFlash-Sata v10](https://www.iflash.xyz/store/iflash-sata-v10/).
+The **PSBBN Definitive Project** can be installed on PS2 Slim **SCPH-700xx** models with an [IDE Resurrector](https://gusse.in/shop/ps2-modding-parts/ide-resurrector-origami-v0-7-flex-cable-for-ps2-slim-spch700xx/) or similar hardware mod. Installing to an SD card is not supported on Windows. For PSBBN compatibility, a SATA adapter must be used, such as the [iFlash-Sata v10](https://www.iflash.xyz/store/iflash-sata-v10/).
 
 You must also download the [External HDD Drivers](https://israpps.github.io/FreeMcBoot-Installer/test/8_Downloads.html). Extract the files and place `hddload.irx`, `dev9.irx`, and `atad.irx` in the appropriate system folder for your region on an **official Sony PS2 Memory Card**:
 

--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ For the best experience, a PS2 Fat model (SCPH-30000 to SCPH-55000 series) is re
 The **PSBBN Definitive Project** requires an x86-64 or ARM64 PC for installation. Connect the HDD or SSD to the PC via SATA or a USB adapter.
 
 ## Installing on Linux
-64-bit Debian-based distributions using `apt`, Arch-based distributions using `pacman`, and Fedora-based[*](#troubleshooting) distributions using `dnf` are supported. Nix-based systems are also supported via flakes. Recommended distributions are Linux Mint, Debian, and for Raspberry Pi, Raspberry Pi OS.
+64-bit Debian-based distributions using `apt`, Arch-based distributions using `pacman`, Fedora-based[*](#troubleshooting) distributions using `dnf`, and Gentoo-based distributions using `emerge` are supported. Nix-based systems are also supported via flakes. Recommended distributions are Linux Mint, Debian, and for Raspberry Pi, Raspberry Pi OS.
 
 **The PSBBN Definitive Project is a rolling release. To get automatic updates and the latest bug fixes, you must install the scripts using `git clone`.**
 

--- a/scripts/Extras.sh
+++ b/scripts/Extras.sh
@@ -1395,10 +1395,10 @@ option_three() {
     if [ "$OS" = "PSBBN" ]; then
         # Download the HTML of the page
         HTML_FILE=$(mktemp)
-        timeout 20 wget -O "$HTML_FILE" "$URL" -o - >> "$LOG_FILE" 2>&1 &
-        WGET_PID=$!
+        curl -sSL -m 20 -o "$HTML_FILE" "$URL" >> "$LOG_FILE" 2>&1 &
+        CURL_PID=$!
 
-        spinner $WGET_PID "${UI_TEXT[CHANGE_LANGUAGE_10]}"
+        spinner $CURL_PID "${UI_TEXT[CHANGE_LANGUAGE_10]}"
 
         get_latest_file "language-pak-$lang" "$LANG_DISPLAY ${UI_TEXT[CHANGE_LANGUAGE_11]}" || return 1
         downoad_latest_file "language-pak-$lang" || return 1

--- a/scripts/Game-Installer.sh
+++ b/scripts/Game-Installer.sh
@@ -473,7 +473,7 @@ POPS_PATCH_DL() {
         wget -qO- 'https://www.mediafire.com/file/rznkr05pci45w5p/Hugopocked_POPStarter_Fixes_%25282023-08-11%2529.rar/file' \
         | grep -o 'https://download[^"]*Hugopocked+POPStarter+Fixes+%282023-08-11%29.rar' | head -n1)"
 
-    unrar-free x "${ASSETS_DIR}/Hugopocked_POPStarter_Fixes.rar" "$ASSETS_DIR"
+    bsdtar -xf "${ASSETS_DIR}/Hugopocked_POPStarter_Fixes.rar" -C "$ASSETS_DIR"
 }
 
 CREATE_PS1_VMC() {

--- a/scripts/Game-Installer.sh
+++ b/scripts/Game-Installer.sh
@@ -920,7 +920,7 @@ install_pops() {
             if [[ -f "${ASSETS_DIR}/POPS-binaries-main.zip" && ! -f "${ASSETS_DIR}/POPS-binaries-main.zip.st" ]]; then
                 echo | tee -a "${LOG_FILE}"
                 echo "POPS-binaries-main.zip found in ${ASSETS_DIR}. Extracting..." >> "${LOG_FILE}"
-                if ! unzip -o "${ASSETS_DIR}/POPS-binaries-main.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1; then
+                if ! bsdtar -xf "${ASSETS_DIR}/POPS-binaries-main.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1; then
                     echo "[!] Warning: Failed to extract POPS binaries." >> "${LOG_FILE}"
                     error_msg "Warning" "${UI_TEXT[WARN_INSTALL_POPS_1]}"
                 fi
@@ -932,7 +932,7 @@ install_pops() {
                     echo "[!] Warning: Failed to download POPS binaries." >> "${LOG_FILE}"
                     error_msg "Warning" "Failed to download POPS binaries."
                 fi
-                if ! unzip -o "${ASSETS_DIR}/POPS-binaries-main.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1; then
+                if ! bsdtar -xf "${ASSETS_DIR}/POPS-binaries-main.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1; then
                     error_msg "Warning" "${UI_TEXT[WARN_INSTALL_POPS_2]}"
                 fi
             fi
@@ -3943,9 +3943,9 @@ cp "${MISSING_ICON}" "${ICONS_DIR}/ico/tmp" >> "${LOG_FILE}" 2>&1
 
 cd "${ICONS_DIR}/ico/tmp/"
 rm *.png >/dev/null 2>&1
-zip -r "${ARTWORK_DIR}/tmp/ico.zip" * >/dev/null 2>&1
+bsdtar -acf "${ARTWORK_DIR}/tmp/ico.zip" * >/dev/null 2>&1
 cd "${ARTWORK_DIR}/tmp/" 
-zip -r "${ARTWORK_DIR}/tmp/art.zip" * >/dev/null 2>&1
+bsdtar -acf "${ARTWORK_DIR}/tmp/art.zip" * >/dev/null 2>&1
 
 if [ -f "${ARTWORK_DIR}/tmp/art.zip" ]; then
     echo "Contributing to the PSBBN art & HDD-OSD databases..." >> "${LOG_FILE}"

--- a/scripts/Game-Installer.sh
+++ b/scripts/Game-Installer.sh
@@ -469,10 +469,7 @@ process_psu_files() {
 }
 
 POPS_PATCH_DL() {
-    wget -O "$ASSETS_DIR/Hugopocked_POPStarter_Fixes.rar" "$(
-        wget -qO- 'https://www.mediafire.com/file/rznkr05pci45w5p/Hugopocked_POPStarter_Fixes_%25282023-08-11%2529.rar/file' \
-        | grep -o 'https://download[^"]*Hugopocked+POPStarter+Fixes+%282023-08-11%29.rar' | head -n1)"
-
+    curl -sSL -o "$ASSETS_DIR/Hugopocked_POPStarter_Fixes.rar" "$(curl -sL 'https://www.mediafire.com/file/rznkr05pci45w5p/Hugopocked_POPStarter_Fixes_%25282023-08-11%2529.rar/file' | grep -oE 'https://download[^\"]+' | head -n1)"
     bsdtar -xf "${ASSETS_DIR}/Hugopocked_POPStarter_Fixes.rar" -C "$ASSETS_DIR"
 }
 
@@ -1431,7 +1428,7 @@ APP_ART() {
         echo "Created: ${SCRIPTS_DIR}/tmp/${pp_name}/jkt_001.png"  >> "${LOG_FILE}"
     elif [ ! -s "$png_file" ]; then
         echo "Artwork not found locally for $APP_ID. Attempting to download from the PSBBN art database..." >> "${LOG_FILE}"
-        wget --quiet --timeout=10 --tries=3 --output-document="$png_file" \
+        curl -s -m 10 --retry 3 -o "$png_file" \
         "https://raw.githubusercontent.com/CosmicScale/psbbn-art-database/main/apps/${APP_ID}.png"
         
         if [[ -s "$png_file" ]]; then
@@ -1706,15 +1703,15 @@ create_game_assets() {
                 if [[ -f "$png_file" ]]; then
                     echo "Artwork for $game_id already exists. Skipping download." >> "${LOG_FILE}"
                 else
-                    # Attempt to download artwork using wget
+                    # Attempt to download artwork using curl
                     echo -n "Artwork not found locally. Attempting to download from the PSBBN art database..." >> "${LOG_FILE}"
                     echo >> "${LOG_FILE}"
-                    wget --quiet --timeout=10 --tries=3 --output-document="$png_file" \
+                    curl s -m 10 --retry 3 -o "$png_file" \
                     "https://raw.githubusercontent.com/CosmicScale/psbbn-art-database/main/art/${game_id}.png"
                     if [[ -s "$png_file" ]]; then
                         echo "[✓] Successfully downloaded artwork for $game_id" >> "${LOG_FILE}"
                     else
-                        # If wget fails, run the art downloader
+                        # If curl fails, run the art downloader
                         [[ -f "$png_file" ]] && rm -f "$png_file"
                         echo "Trying IGN for $game_id" >> "${LOG_FILE}"
                         "${HELPER_DIR}/art_downloader.py" "$game_id" 2>&1 >> "${LOG_FILE}"
@@ -1782,14 +1779,14 @@ create_game_assets() {
             ico_file="${ICONS_DIR}/ico/$game_id.ico"
             
             if [[ ! -s "$ico_file" ]]; then
-                # Attempt to download icon using wget
+                # Attempt to download icon using curl
                 echo -n "Icon not found locally for $game_id. Attempting to download from the HDD-OSD icon database..." >> "${LOG_FILE}"
-                wget --quiet --timeout=10 --tries=3 --output-document="$ico_file" \
+                curl -s -m 10 --retry 3 -o "$ico_file" \
                 "https://raw.githubusercontent.com/CosmicScale/HDD-OSD-Icon-Database/main/ico/${game_id}.ico"
                 if [[ -s "$ico_file" ]]; then
                     echo "[✓] Successfully downloaded icon for ${game_id}." >> "${LOG_FILE}"
                 else
-                    # If wget fails, run the art downloader
+                    # If curl fails, run the art downloader
                     [[ -f "$ico_file" ]] && rm -f "$ico_file"
 
                     png_file_cov="${TOOLKIT_PATH}/icons/ico/tmp/${game_id}_COV.png"
@@ -1803,18 +1800,18 @@ create_game_assets() {
                     fi
 
                     if [[ "$disc_type" == "POPS" || "$disc_type" == "__.POPS" || "$disc_type" == "SMB" ]]; then
-                        wget --quiet --timeout=10 --tries=3 --output-document="${png_file_cov}" \
+                        curl -s -m 10 --retry 3 -o "${png_file_cov}" \
                         "https://archive.org/download/OPLM_ART_2024_09/OPLM_ART_2024_09.zip/PS1/${game_id}/${game_id}_COV.png"
                         if [[ -s "$png_file_cov" ]]; then
-                            wget --quiet --timeout=10 --tries=3 --output-document="$png_file_cov2" \
+                            curl -s -m 10 --retry 3 -o "$png_file_cov2" \
                             "https://archive.org/download/OPLM_ART_2024_09/OPLM_ART_2024_09.zip/PS1/${game_id}/${game_id}_COV2.png"
-                            wget --quiet --timeout=10 --tries=3 --output-document="$png_file_lab" \
+                            curl -s -m 10 --retry 3 -o "$png_file_lab" \
                             "https://archive.org/download/OPLM_ART_2024_09/OPLM_ART_2024_09.zip/PS1/${game_id}/${game_id}_LAB.png"
                         fi
                     elif [[ -s "$png_file_cov"  ]]; then
-                        wget --quiet --timeout=10 --tries=3 --output-document="$png_file_cov2" \
+                        curl -s -m 10 --retry 3 -o "$png_file_cov2" \
                         "https://archive.org/download/OPLM_ART_2024_09/OPLM_ART_2024_09.zip/PS2/${game_id}/${game_id}_COV2.png"
-                        wget --quiet --timeout=10 --tries=3 --output-document="$png_file_lab" \
+                        curl -s -m 10 --retry 3 -o "$png_file_lab" \
                         "https://archive.org/download/OPLM_ART_2024_09/OPLM_ART_2024_09.zip/PS2/${game_id}/${game_id}_LAB.png"
                     fi
 
@@ -3012,11 +3009,11 @@ if [ -f "${PS2_LIST}" ]; then
         if [[ -f "$png_file_cover" ]]; then
             echo "OPL Artwork for $game_id already exists. Skipping download." >> "${LOG_FILE}"
         else
-            # Attempt to download artwork using wget
+            # Attempt to download artwork using curl
             echo "OPL Artwork not found locally for $game_id. Attempting to download from archive.org..." >> "${LOG_FILE}"
-            wget --quiet --timeout=10 --tries=3 --output-document="$png_file_cover" \
+            curl -s -m 10 --retry 3 -o "$png_file_cover" \
             "https://archive.org/download/OPLM_ART_2024_09/OPLM_ART_2024_09.zip/PS2/${game_id}/${game_id}_COV.png"
-            #wget --quiet --timeout=10 --tries=3 --output-document="$png_file_disc" \
+            #curl -s -m 10 --retry 3 -o "$png_file_disc" \
             #"https://archive.org/download/OPLM_ART_2024_09/OPLM_ART_2024_09.zip/PS2/${game_id}/${game_id}_ICO.png"
 
             missing_files=()
@@ -3069,9 +3066,9 @@ if [ -f "${ATA_POPS_LIST}" ]; then
         if [[ -f "$png_file_cover" ]]; then
             echo "POPSLoader Artwork for $filename already exists. Skipping download." >> "${LOG_FILE}"
         else
-            # Attempt to download artwork using wget
+            # Attempt to download artwork using curl
             echo "POPSLoader Artwork not found locally for $filename. Attempting to download from archive.org..." >> "${LOG_FILE}"
-            wget --quiet --timeout=10 --tries=3 --output-document="$png_file_cover" \
+            curl -s -m 10 --retry 3 -o "$png_file_cover" \
             "https://archive.org/download/OPLM_ART_2024_09/OPLM_ART_2024_09.zip/PS1/${game_id}/${game_id}_COV.png"
 
             missing_files=()

--- a/scripts/HOSDMenu-Installer.sh
+++ b/scripts/HOSDMenu-Installer.sh
@@ -367,14 +367,14 @@ download_files() {
         # Check if extras.zip exists
         if [[ -f "${ASSETS_DIR}/extras.zip" && ! -f "${ASSETS_DIR}/extras.zip.st" ]]; then
             echo "extras.zip found in ${ASSETS_DIR}. Extracting..." >> "${LOG_FILE}"
-            unzip -o "${ASSETS_DIR}/extras.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
+            bsdtar -xf "${ASSETS_DIR}/extras.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
         else
             echo "Downloading..." >> "${LOG_FILE}"
             echo -n "${UI_TEXT[DOWNLOAD_LATEST_FILE_2]}..."
             wget --quiet --timeout=10 --tries=3 -O "${ASSETS_DIR}/extras.zip" https://archive.org/download/psbbn-definitive-english-patch-v2/extras.zip
             echo
             if [[ -s "${ASSETS_DIR}/extras.zip" ]]; then
-                unzip -o "${ASSETS_DIR}/extras.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
+                bsdtar -xf "${ASSETS_DIR}/extras.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
             else
                 rm "${ASSETS_DIR}/extras.zip"
                 echo "[X] Error: Download failed for HDD-OSD." >> "${LOG_FILE}" 2>&1

--- a/scripts/HOSDMenu-Installer.sh
+++ b/scripts/HOSDMenu-Installer.sh
@@ -371,7 +371,7 @@ download_files() {
         else
             echo "Downloading..." >> "${LOG_FILE}"
             echo -n "${UI_TEXT[DOWNLOAD_LATEST_FILE_2]}..."
-            wget --quiet --timeout=10 --tries=3 -O "${ASSETS_DIR}/extras.zip" https://archive.org/download/psbbn-definitive-english-patch-v2/extras.zip
+            curl -s -m 10 --retry 3 -o "${ASSETS_DIR}/extras.zip" https://archive.org/download/psbbn-definitive-english-patch-v2/extras.zip
             echo
             if [[ -s "${ASSETS_DIR}/extras.zip" ]]; then
                 bsdtar -xf "${ASSETS_DIR}/extras.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1

--- a/scripts/Media-Installer.sh
+++ b/scripts/Media-Installer.sh
@@ -583,14 +583,14 @@ download_ps2str() {
     if [[ -f "${ASSETS_DIR}/ps2str_v1.08_2001.zip" ]]; then
       echo "Found ${ASSETS_DIR}/ps2str_v1.08_2001.zip..." >> "${LOG_FILE}"
         echo "${UI_TEXT[GET_LATEST_FILE_1]} ${ASSETS_DIR}/ps2str_v1.08_2001.zip..."
-        unzip -o "${ASSETS_DIR}/ps2str_v1.08_2001.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
+        bsdtar -xf "${ASSETS_DIR}/ps2str_v1.08_2001.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
     else
         echo "Downloading ps2str..." >> "${LOG_FILE}"
         echo "${UI_TEXT[DOWNLOAD_REQUIRED]}"
         wget --quiet --timeout=10 --tries=3 -O "${ASSETS_DIR}/ps2str_v1.08_2001.zip" https://archive.org/download/ps2str_v1.08_2001/ps2str_v1.08_2001.zip
         echo
         if [[ -s "${ASSETS_DIR}/ps2str_v1.08_2001.zip" ]]; then
-            unzip -o "${ASSETS_DIR}/ps2str_v1.08_2001.zip" -d "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
+            bsdtar -xf "${ASSETS_DIR}/ps2str_v1.08_2001.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1
         fi
     fi
 }

--- a/scripts/Media-Installer.sh
+++ b/scripts/Media-Installer.sh
@@ -587,7 +587,7 @@ download_ps2str() {
     else
         echo "Downloading ps2str..." >> "${LOG_FILE}"
         echo "${UI_TEXT[DOWNLOAD_REQUIRED]}"
-        wget --quiet --timeout=10 --tries=3 -O "${ASSETS_DIR}/ps2str_v1.08_2001.zip" https://archive.org/download/ps2str_v1.08_2001/ps2str_v1.08_2001.zip
+        curl -s -m 10 --retry 3 -o "${ASSETS_DIR}/ps2str_v1.08_2001.zip" https://archive.org/download/ps2str_v1.08_2001/ps2str_v1.08_2001.zip
         echo
         if [[ -s "${ASSETS_DIR}/ps2str_v1.08_2001.zip" ]]; then
             bsdtar -xf "${ASSETS_DIR}/ps2str_v1.08_2001.zip" -C "${ASSETS_DIR}" >> "${LOG_FILE}" 2>&1

--- a/scripts/PSBBN-Installer.sh
+++ b/scripts/PSBBN-Installer.sh
@@ -1049,10 +1049,10 @@ fi
 if [ "$OS" = "PSBBN" ]; then
     # Download the HTML of the page
     HTML_FILE=$(mktemp)
-    timeout 20 wget -O "$HTML_FILE" "$URL" -o - >> "$LOG_FILE" 2>&1 &
-    WGET_PID=$!
+    curl -sSL -m 20 -o "$HTML_FILE" "$URL" >> "$LOG_FILE" 2>&1 &
+    CURL_PID=$!
 
-    spinner $WGET_PID "${UI_TEXT[VERSION_CHECK_PSBBN]}"
+    spinner $CURL_PID "${UI_TEXT[VERSION_CHECK_PSBBN]}"
 
     get_latest_file "psbbn-definitive-patch" "PSBBN Definitive Patch"
 

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -144,14 +144,14 @@ elif [ -x "$(command -v emerge)" ]; then
     fi
     # Check if device-mapper is in the user's kernel
     # First, see if it's built in
-    if grep -q "device-mapper" /proc/devices 2>/dev/null && ! lsmod 2>/dev/null | grep -q "^dm_mod"; then
+    if grep -q "device-mapper" /proc/devices 2>/dev/null && ! lsmod 2>/dev/null | grep -q "^dm_mod"; then :
     # If it's not built in, see if it's configured as a module
     elif modprobe -n dm_mod &>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then
         # If it's a module, check if it's loaded
-        if grep -q "device-mapper" /proc/devices 2>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then
+        if grep -q "device-mapper" /proc/devices 2>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then :
         else
         # If it's not loaded, attempt to load it
-        if sudo modprobe dm_mod 2>/dev/null; then
+        if sudo modprobe dm_mod 2>/dev/null; then :
         else
         echo "Error: Failed to load the 'dm_mod' kernel module." >&2
         exit 1

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -123,20 +123,20 @@ if [ -x "$(command -v apt-get)" ]; then
         sudo dpkg --add-architecture i386
         i386="libc6:i386"
     fi
-    sudo apt-get -q update && sudo apt-get install -y axel imagemagick xxd python3 python3-venv python3-pip bc rsync curl wget ffmpeg lvm2 libfuse2 dosfstools e2fsprogs libc-bin exfatprogs exfat-fuse util-linux fdisk parted bchunk build-essential libicu-dev pkg-config ffmpegthumbnailer binfmt-support libarchive-tools dmsetup $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo apt-get -q update && sudo apt-get install -y axel imagemagick xxd python3 python3-venv python3-pip bc rsync curl ffmpeg lvm2 libfuse2 dosfstools e2fsprogs libc-bin exfatprogs exfat-fuse util-linux fdisk parted bchunk build-essential libicu-dev pkg-config ffmpegthumbnailer binfmt-support libarchive-tools dmsetup $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Fedora-based system, do this instead
 elif [ -x "$(command -v dnf)" ]; then
     if [[ "$arch" = "x86_64" ]]; then
         i386="glibc.i686"
     fi
     sudo dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm 2>&1 | tee -a "${LOG_FILE}"
-    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer libarchive bsdtar device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer libarchive bsdtar device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Arch-based system, do this instead
 elif [ -x "$(command -v pacman)" ]; then
     if [[ "$arch" = "x86_64" ]]; then
         i386="lib32-glibc"
     fi
-    sudo pacman -S --needed --noconfirm axel imagemagick xxd python pyenv python-pip bc rsync curl wget ffmpeg lvm2 fuse2 dosfstools e2fsprogs glibc exfatprogs util-linux parted bchunk base-devel icu pkgconf ffmpegthumbnailer libarchive device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo pacman -S --needed --noconfirm axel imagemagick xxd python pyenv python-pip bc rsync curl ffmpeg lvm2 fuse2 dosfstools e2fsprogs glibc exfatprogs util-linux parted bchunk base-devel icu pkgconf ffmpegthumbnailer libarchive device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Gentoo-based system, do this instead
 elif [ -x "$(command -v emerge)" ]; then
     if [[ "$arch" = "x86_64" ]]; then
@@ -186,7 +186,7 @@ EOF
             esac
         done
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge --update --quiet --quiet-fail --changed-use --ask net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge --update --quiet --quiet-fail --changed-use --ask net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -143,13 +143,10 @@ elif [ -x "$(command -v emerge)" ]; then
         i386="glibc"
     fi
     # Check if device-mapper is in the user's kernel
-    # First, see if it's built in
+    # First, see if it's built into the kernel or if it's a module and currently loaded
     if grep -q "device-mapper" /proc/devices 2>/dev/null && ! lsmod 2>/dev/null | grep -q "^dm_mod"; then :
-    # If it's not built in, see if it's configured as a module
-    elif modprobe -n dm_mod &>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then
-        # If it's a module, check if it's loaded
-        if grep -q "device-mapper" /proc/devices 2>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then :
-        else
+    # If it's not built in or loaded, check if it's built as a module but not currently loaded
+    elif modprobe -n dm_mod &>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then   
         # If it's not loaded, attempt to load it
         if sudo modprobe dm_mod 2>/dev/null; then :
         else
@@ -189,7 +186,7 @@ EOF
             esac
         done
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge --noreplace --quiet --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge --update --quiet --quiet-fail --changed-use --ask net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -171,11 +171,25 @@ media-video/ffmpeg opus
 EOF
 # Swap deprecated exfat-utils with exfatprogs if present
     if portageq has_version / sys-fs/exfat-utils &>/dev/null; then
-        echo "Removing deprecated sys-fs/exfat-utils to prevent package blocks..."
-        sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
-        sudo emerge --unmerge --quiet sys-fs/exfat-utils
+        while true; do
+        read -p "You have deprecated exfat-utils installed. It must be removed for this program to function. Do you want to remove it now and replace it with exfatprogs? (y/n): " yn
+        case $yn in
+            [Yy]* )
+                sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
+                sudo emerge --unmerge --quiet sys-fs/exfat-utils
+                break
+                ;;
+            [Nn]* )
+                echo "Please remove sys-fs/exfat-utils manually before running this script again."
+                exit 0
+                ;;
+            * )
+                echo "Invalid input! Please enter y or n."
+                ;;
+            esac
+        done
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge --noreplace --quiet --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge --noreplace --quiet --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -163,7 +163,19 @@ elif [ -x "$(command -v emerge)" ]; then
     echo "Please rebuild your kernel with CONFIG_BLK_DEV_DM=y or CONFIG_BLK_DEV_DM=m before running this installer." >&2
         exit 1
     fi
-    sudo USE='lvm' emerge --ask net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo mkdir -p /etc/portage/package.use
+    cat << 'EOF' | sudo tee /etc/portage/package.use/psbbn-installer > /dev/null
+    # Specific USE requirements for PSBBN installer dependencies
+sys-fs/lvm2 lvm
+media-video/ffmpeg opus
+EOF
+# Swap deprecated exfat-utils with exfatprogs if present
+    if portageq has_version / sys-fs/exfat-utils &>/dev/null; then
+        echo "Removing deprecated sys-fs/exfat-utils to prevent package blocks..."
+        sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
+        sudo emerge --unmerge --quiet sys-fs/exfat-utils
+    fi
+    sudo emerge --sync && sudo USE='lvm' emerge -q --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -175,7 +175,7 @@ EOF
         sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
         sudo emerge --unmerge --quiet sys-fs/exfat-utils
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge -q --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge -q --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -130,7 +130,7 @@ elif [ -x "$(command -v dnf)" ]; then
         i386="glibc.i686"
     fi
     sudo dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm 2>&1 | tee -a "${LOG_FILE}"
-    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer bsdtar device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer libarchive bsdtar device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Arch-based system, do this instead
 elif [ -x "$(command -v pacman)" ]; then
     if [[ "$arch" = "x86_64" ]]; then

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -175,7 +175,7 @@ EOF
         sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
         sudo emerge --unmerge --quiet sys-fs/exfat-utils
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge -q --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge -qn --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -123,20 +123,47 @@ if [ -x "$(command -v apt-get)" ]; then
         sudo dpkg --add-architecture i386
         i386="libc6:i386"
     fi
-    sudo apt-get -q update && sudo apt-get install -y axel imagemagick xxd python3 python3-venv python3-pip bc rsync curl zip unzip wget ffmpeg lvm2 libfuse2 dosfstools e2fsprogs libc-bin exfatprogs exfat-fuse util-linux fdisk parted bchunk build-essential libicu-dev pkg-config ffmpegthumbnailer binfmt-support unrar-free dmsetup $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo apt-get -q update && sudo apt-get install -y axel imagemagick xxd python3 python3-venv python3-pip bc rsync curl wget ffmpeg lvm2 libfuse2 dosfstools e2fsprogs libc-bin exfatprogs exfat-fuse util-linux fdisk parted bchunk build-essential libicu-dev pkg-config ffmpegthumbnailer binfmt-support libarchive-tools dmsetup $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Fedora-based system, do this instead
 elif [ -x "$(command -v dnf)" ]; then
     if [[ "$arch" = "x86_64" ]]; then
         i386="glibc.i686"
     fi
     sudo dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm 2>&1 | tee -a "${LOG_FILE}"
-    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl zip unzip wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer unrar-free device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo dnf install -y gcc-c++ axel ImageMagick xxd python3 python3-devel python3-pip bc rsync curl wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted bchunk libicu-devel pkgconf ffmpegthumbnailer bsdtar device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Arch-based system, do this instead
 elif [ -x "$(command -v pacman)" ]; then
     if [[ "$arch" = "x86_64" ]]; then
         i386="lib32-glibc"
     fi
-    sudo pacman -S --needed --noconfirm axel imagemagick xxd python pyenv python-pip bc rsync curl zip unzip wget ffmpeg lvm2 fuse2 dosfstools e2fsprogs glibc exfatprogs util-linux parted bchunk base-devel icu pkgconf ffmpegthumbnailer unrar-free device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo pacman -S --needed --noconfirm axel imagemagick xxd python pyenv python-pip bc rsync curl wget ffmpeg lvm2 fuse2 dosfstools e2fsprogs glibc exfatprogs util-linux parted bchunk base-devel icu pkgconf ffmpegthumbnailer libarchive device-mapper $i386 2>&1 | tee -a "${LOG_FILE}"
+# Or if user is on Gentoo-based system, do this instead
+elif [ -x "$(command -v emerge)" ]; then
+    if [[ "$arch" = "x86_64" ]]; then
+        i386="glibc"
+    fi
+    # Check if device-mapper is in the user's kernel
+    # First, see if it's built in
+    if grep -q "device-mapper" /proc/devices 2>/dev/null && ! lsmod 2>/dev/null | grep -q "^dm_mod"; then
+    # If it's not built in, see if it's configured as a module
+    elif modprobe -n dm_mod &>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then
+        # If it's a module, check if it's loaded
+        if grep -q "device-mapper" /proc/devices 2>/dev/null || lsmod 2>/dev/null | grep -q "^dm_mod"; then
+        else
+        # If it's not loaded, attempt to load it
+        if sudo modprobe dm_mod 2>/dev/null; then
+        else
+        echo "Error: Failed to load the 'dm_mod' kernel module." >&2
+        exit 1
+        fi
+    fi
+    else
+    # If it's not present at all, halt and throw this error message
+    echo "Error: device-mapper (CONFIG_BLK_DEV_DM) is missing from your kernel." >&2
+    echo "Please rebuild your kernel with CONFIG_BLK_DEV_DM=y or CONFIG_BLK_DEV_DM=m before running this installer." >&2
+        exit 1
+    fi
+    sudo USE='lvm' emerge --ask net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -175,7 +175,7 @@ EOF
         sudo emerge --deselect sys-fs/exfat-utils &>/dev/null
         sudo emerge --unmerge --quiet sys-fs/exfat-utils
     fi
-    sudo emerge --sync && sudo USE='lvm' emerge -qn --ask=n --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
+    sudo emerge --sync && sudo USE='lvm' emerge --noreplace --quiet --quiet-fail --autounmask=y --autounmask-continue=y --autounmask-write=y -- net-misc/axel media-gfx/imagemagick dev-util/xxd dev-lang/python dev-python/pip sys-devel/bc net-misc/rsync net-misc/curl net-misc/wget media-video/ffmpeg sys-fs/lvm2 sys-fs/fuse:0 sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/exfatprogs sys-apps/util-linux sys-block/parted app-cdr/bchunk dev-libs/icu dev-util/pkgconf media-video/ffmpegthumbnailer app-arch/libarchive $i386 2>&1 | tee -a "${LOG_FILE}"
 elif [ -n "$IN_NIX_SHELL" ]; then
     echo Running in Nix environment - packages should be provided by flake and setup should not be run. >> "${LOG_FILE}"
     error_msg "${UI_TEXT[ERROR_NIX]}"

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -40,7 +40,6 @@
           bc
           rsync
           curl
-          wget
           exfatprogs
           ffmpeg
           parted

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -40,8 +40,6 @@
           bc
           rsync
           curl
-          zip
-          unzip
           wget
           exfatprogs
           ffmpeg
@@ -50,7 +48,7 @@
           bchunk
           e2fsprogs
           ffmpegthumbnailer
-          unrar-free
+          libarchive
           lvm2
           dosfstools
           util-linux


### PR DESCRIPTION
This is very minor but `wget` is redundant in these scripts, so this is a patch on top of my previous Gentoo one to remove `wget` installation and use equivalent `curl` commands instead. This just means one less package for the user to install and maintain should they not want it. Pretty niche but also no downside. Separate PR in case you plan on using some obscure wget-exclusive feature in a future update and want to continue pulling it.